### PR TITLE
Removed slow $request->get calls in post action

### DIFF
--- a/src/Puphpet/Controller/Front.php
+++ b/src/Puphpet/Controller/Front.php
@@ -60,12 +60,12 @@ class Front extends Controller
 
     public function createAction(Request $request)
     {
-        $box = $request->get('box');
+        $box = $request->request->get('box');
 
-        $server = new Domain\PuppetModule\Server($request->get('server'));
-        $apache = new Domain\PuppetModule\Apache($request->get('apache'));
-        $mysql  = new Domain\PuppetModule\MySQL($request->get('mysql'));
-        $php    = new Domain\PuppetModule\PHP($request->get('php'));
+        $server = new Domain\PuppetModule\Server($request->request->get('server'));
+        $apache = new Domain\PuppetModule\Apache($request->request->get('apache'));
+        $mysql  = new Domain\PuppetModule\MySQL($request->request->get('mysql'));
+        $php    = new Domain\PuppetModule\PHP($request->request->get('php'));
 
         $server = $server->getFormatted();
         $apache = $apache->getFormatted();


### PR DESCRIPTION
The get method in the Request class is quite slow as all the GET, PATH and POST variables are checked. 
It is better to call directly the needed getter for the http method. $request->query->get for a GET method nd $request->request->get for a POST method.
As the creation action is a POST method I replaced the $request->get calls to $request->request->get
