### PR TITLE
Rendering GA tag only in prod mode

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -12,6 +12,7 @@ defined('VAGRANT_PATH')
 $app = new Silex\Application;
 
 $env = getenv('APP_ENV') ? : 'prod';
+$app['debug'] = $env != 'prod';
 
 $app->register(
     new Provider\TwigServiceProvider,

--- a/src/Puphpet/View/Front/layout.html.twig
+++ b/src/Puphpet/View/Front/layout.html.twig
@@ -70,6 +70,7 @@
         <script src="/assets/vendor/select2/select2.js"></script>
         <script src="/assets/vendor/bootstrap-multiselect/bootstrap-multiselect.js"></script>
         <script src="/assets/js/custom.js"></script>
+{% if not app.debug %}
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -79,6 +80,7 @@
           ga('create', 'UA-29873536-2', 'puphpet.com');
           ga('send', 'pageview');
         </script>
+{% endif %}
     {% endblock %}
 {% endblock %}
 </body>


### PR DESCRIPTION
After defining APP_ENV as 'dev' in my vhost I am able to skip rendering of the GA tag on my dev box.
