### PR TITLE
Fixed the php.ini configuration in ManifestTest

### DIFF
--- a/tests/Puphpet/Tests/Domain/PuppetModule/PHPTest.php
+++ b/tests/Puphpet/Tests/Domain/PuppetModule/PHPTest.php
@@ -7,6 +7,7 @@ use Puphpet\Domain\PuppetModule\PHP;
 class PHPTest extends \PHPUnit_Framework_TestCase
 {
     protected $phpArray = array();
+    protected $expectedIniListCustom = array();
 
     public function setUp()
     {
@@ -35,6 +36,12 @@ class PHPTest extends \PHPUnit_Framework_TestCase
             'inilist'  => [
                 'custom' => 'date.timezone = America/Chicago,display_errors = On,error_reporting = 1',
             ],
+        ];
+
+        $this->expectedIniListCustom = [
+            'date.timezone = America/Chicago',
+            'display_errors = On',
+            'error_reporting = 1'
         ];
     }
 
@@ -69,7 +76,7 @@ class PHPTest extends \PHPUnit_Framework_TestCase
         unset($this->phpArray['modules'][$moduleType]);
 
         $expected['modules'][$moduleType] = array();
-        $expected['inilist']['custom']    = explode(',', $expected['inilist']['custom']);
+        $expected['inilist']['custom']    = $this->expectedIniListCustom;
 
         $php = new PHP($this->phpArray);
 
@@ -193,7 +200,7 @@ class PHPTest extends \PHPUnit_Framework_TestCase
     {
         $expected = $this->phpArray;
 
-        $expected['inilist']['custom'] = explode(',', $expected['inilist']['custom']);
+        $expected['inilist']['custom'] = $this->expectedIniListCustom;
 
         $php = new PHP($this->phpArray);
         $result = $php->getFormatted();

--- a/tests/Puphpet/Tests/View/Vagrant/ManifestTest.php
+++ b/tests/Puphpet/Tests/View/Vagrant/ManifestTest.php
@@ -43,7 +43,12 @@ class ManifestTest extends Base
                 'xdebug'   => true,
                 'composer' => true,
                 'modules'  => ['php' => ['php5-cli'], 'pear' => array(), 'pecl' => array()],
-                'inilist'  => ['custom' => 'date.timezone = America/Chicago,display_errors = On,error_reporting = 1']
+                'inilist'  => ['custom' => [
+                    'date.timezone = America/Chicago',
+                    'display_errors = On',
+                    'error_reporting = 1'
+                    ]
+                ],
             ],
             'mysql'       => [
                 'root'   => 'rootpwd',
@@ -68,5 +73,6 @@ class ManifestTest extends Base
         $this->assertContains("php::module { 'php5-cli'", $rendered);
         $this->assertContains("root_password => 'rootpwd'", $rendered);
         $this->assertContains("mysql::grant { 'test_dbname'", $rendered);
+        $this->assertContains("date.timezone = America/Chicago", $rendered);
     }
 }


### PR DESCRIPTION
I have just seen that the php.ini configuration was not exploded in the fixtures. 
