### PR TITLE
integrated optional puppet-lint check to ManifestTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-cache
+cache/*.pp
 config/prod.yml
 log
 tests/codeCoverage
+web/coverage
 phpunit.xml
 twig.cache
 /vendor

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is the repo for the [PuPHPet.com](https://puphpet.com) website. A proper RE
 Requirements
 ------------
 * PHP 5.4
+* For executing all the tests [puppet-lint](http://packages.ubuntu.com/precise/puppet-lint) has to be installed on your machine
 
 Used Puppet Modules
 ===================

--- a/cache/.gitkeep
+++ b/cache/.gitkeep
@@ -1,0 +1,1 @@
+# do not delete me

--- a/src/Puphpet/View/Vagrant/Modules/php.pp.twig
+++ b/src/Puphpet/View/Vagrant/Modules/php.pp.twig
@@ -43,8 +43,8 @@ class { 'php::composer': }
 
 {% for name,settings in php.inilist if settings is not empty %}
 php::ini { '{{ name }}':
-  value  => [{{ format.explode_and_quote(settings)|raw }}],
-  target => '{{ name }}.ini',
+  value   => [{{ format.explode_and_quote(settings)|raw }}],
+  target  => '{{ name }}.ini',
   service => '{{ php_service }}',
 }
 {% endfor %}

--- a/src/Puphpet/View/Vagrant/manifest.pp.twig
+++ b/src/Puphpet/View/Vagrant/manifest.pp.twig
@@ -17,8 +17,8 @@ package { ['python-software-properties']:
 }
 
 file { '/home/vagrant/.bash_aliases':
-  source => 'puppet:///modules/puphpet/dot/.bash_aliases',
   ensure => 'present',
+  source => 'puppet:///modules/puphpet/dot/.bash_aliases',
 }
 
 {% include 'Vagrant/Modules/server.pp.twig' %}


### PR DESCRIPTION
Within ManifestTest puppet-lint validates the rendered result of Vagrant/manifest.pp.twig. If puppet-lint is not installed on the testing machine the according test is skipped and a warning message is displayed.

The rendered manifest is stored in cache/manifest_lint.pp for better debugging purposes. So .gitignore has to be adepted accordingly.

If the complete downloadable archive is also tested somewhen this check should be integrated there too.

Fixes #19
