### PR TITLE
fixed regression in mysql root pwd js handling

### DIFF
--- a/src/Puphpet/View/Front/Tabs/mysql.html.twig
+++ b/src/Puphpet/View/Front/Tabs/mysql.html.twig
@@ -6,7 +6,7 @@
 <div class="bs-example rootPassword">
     <label for="mysql-root">MySQL Root Password</label>
     <input id="mysql-root" name="mysql[root]"
-           type="text" class="tags" placeholder="root_password" value="" />
+           type="text" placeholder="root_password" value="" />
     <p class="help-block">Assign a password to the root user</p>
 </div>
 


### PR DESCRIPTION
The latest UI changes created a regression in the handling of the mysql root pwd. The js removed always the value of the according input field and it was not possible to add mysql to a vagrant box.
