### PR TITLE
removed articfacts from vagrant-puppet-lamp in created archive

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -61,6 +61,9 @@ $app['manifest_request_formatter'] = function () use ($app) {
 $app['manifest_compiler'] = function () use ($app) {
     return new Puphpet\Domain\Compiler\Compiler($app['twig'], 'Vagrant/manifest.pp.twig');
 };
+$app['readme_compiler'] = function () use ($app) {
+    return new Puphpet\Domain\Compiler\Compiler($app['twig'], 'Vagrant/README.twig');
+};
 $app['property_access_provider'] = function () {
     return new Puphpet\Domain\Configuration\PropertyAccessProvider();
 };

--- a/src/Puphpet/Controller/Front.php
+++ b/src/Puphpet/Controller/Front.php
@@ -98,7 +98,8 @@ class Front extends Controller
 
         // build Vagrantfile
         $box = $request->request->get('box');
-        $vagrantFile = $this->twig()->render('Vagrant/Vagrantfile.twig', ['box' => $box]);
+        $boxConfiguration = ['box' => $box];
+        $vagrantFile = $this->twig()->render('Vagrant/Vagrantfile.twig', $boxConfiguration);
 
         /**@var $domainFile Domain\File build the archive */
         $domainFile = $app['domain_file'];
@@ -111,9 +112,13 @@ class Front extends Controller
             $domainFile->addModuleSource('postgresql', VENDOR_PATH . '/puppetlabs/postgresql');
         }
 
+        $readme = $app['readme_compiler']->compile(array_merge($manifestConfiguration, $boxConfiguration));
+
+
         // creating and building the archive
         $domainFile->createArchive(
             [
+                'README'                                  => $readme,
                 'Vagrantfile'                             => $vagrantFile,
                 'manifests/default.pp'                    => $manifest,
                 'modules/puphpet/files/dot/.bash_aliases' => $manifestConfiguration['server']['bashaliases'],

--- a/src/Puphpet/Domain/File.php
+++ b/src/Puphpet/Domain/File.php
@@ -50,6 +50,7 @@ class File extends Domain
     {
         $this->setPaths();
         $this->copyToTempFolder();
+        $this->cleanupFiles();
 
         foreach ($replacementFiles as $path => $content) {
             $this->copyFile($path, $content);
@@ -94,6 +95,17 @@ class File extends Domain
             // which must contain a "modules" folder
             $this->copySource($moduleSource, $this->tmpPath . '/modules/' . $moduleName);
         }
+    }
+
+    /**
+     * Removes and replaces all files from vagrant-puppet-lamp which may confuse the user
+     * and does not belong directly to the custom vagrant/puppet environment
+     */
+    protected function cleanupFiles()
+    {
+        // remove unneeded files
+        $this->filesystem->remove($this->tmpPath.'/composer.json');
+        $this->filesystem->remove($this->tmpPath.'/README.md');
     }
 
     /**

--- a/src/Puphpet/Domain/Filesystem.php
+++ b/src/Puphpet/Domain/Filesystem.php
@@ -84,6 +84,16 @@ class Filesystem
     }
 
     /**
+     * Removes a file
+     *
+     * @param string $filePath an absolute file path
+     */
+    public function remove($filePath)
+    {
+        unlink($filePath);
+    }
+
+    /**
      * Creates a zip archive
      *
      * @param string $archivePath an absolute path where archive should be created

--- a/src/Puphpet/View/Vagrant/README.twig
+++ b/src/Puphpet/View/Vagrant/README.twig
@@ -1,0 +1,30 @@
+Welcome to your custom Vagrant/Puppet setup powered by puPHPet
+==============================================================
+
+The setup includes:
+-------------------
+* box:       {{ box.name }} ({{ box.url }})
+* webserver: {{ webserver }}
+* database:  {{ database }}
+* PHP:       {{ php.php54 == 1 ? 'PHP 5.4' : 'PHP 5.3' }}
+
+Next steps:
+-----------
+If you have not installed Vagrant yet, go to http://downloads.vagrantup.com/
+
+Copy the contents of this archive to a new folder
+and run there:
+
+$ vagrant up
+
+Afterwards you may access your box with
+
+$ vagrant ssh
+
+More documentation:
+* Vagrant >= 1.1: http://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html
+* Vagrant <  1.1: http://docs-v1.vagrantup.com/v1/docs/getting-started/ssh.html
+
+If you encounter any problems do not hestitate to create an issue on https://github.com/puphpet/puphpet/issues.
+
+Enjoy!

--- a/tests/Puphpet/Tests/View/Vagrant/ReadmeTest.php
+++ b/tests/Puphpet/Tests/View/Vagrant/ReadmeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Puphpet\Tests\View\Vagrant;
+
+use Puphpet\Tests\Base;
+
+/**
+ * @group functional
+ */
+class ReadmeTest extends Base
+{
+    public function setUp()
+    {
+        $this->createApplication();
+    }
+
+    /**
+     * This test is a simple functional test on rendering the manifest template.
+     * It does not analyze its content but it checks if there is rendered something
+     * useful or if any error occurs during rendering.
+     */
+    public function testRender()
+    {
+        $parameters = [
+            'box'         => ['name' => 'precise64', 'url' => 'http://files.vagrantup.com/precise64.box'],
+            'webserver'   => 'apache',
+            'php_service' => 'apache',
+            'php'         => [
+                'pear'     => true,
+                'php54'    => true,
+                'xdebug'   => true,
+                'composer' => true,
+                'modules'  => ['php' => ['php5-cli'], 'pear' => array(), 'pecl' => array()],
+                'inilist'  => [
+                    'php'    => [
+                        'date.timezone = "America/Chicago"',
+                    ],
+                    'custom' => [
+                        'display_errors = On',
+                        'error_reporting = 1'
+                    ]
+                ],
+            ],
+            'database'    => 'mysql',
+        ];
+
+        $rendered = $this->app['readme_compiler']->compile($parameters);
+
+        $this->assertContains('precise64 (http://files.vagrantup.com/precise64.box)', $rendered);
+        $this->assertContains('PHP 5.4', $rendered);
+        $this->assertContains('apache', $rendered);
+        $this->assertContains('mysql', $rendered);
+    }
+}


### PR DESCRIPTION
Currently the README.md and composer.json are contained in the created archive. Those files belong to the vagrant-puppet-lamp repository and do not belong to puPHPet workflow directly. Therefore I removed those lines and provided an own README file which gives the user some more information and hopefully confuses the user no more.
