### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# we actually need both environments PHP and rvm
+# however it is only possible to define the environment for one language
+language: php
+rvm: 1.8.7
+php:
+  - 5.4
+  - 5.5
+
+notifications:
+  email:
+    - jtreminio@gmail.com
+    - dev@frankstelzer.de
+env:
+  - PUPPET_VERSION=2.7.11
+
+before_script:
+  - composer install
+
+# PHPUnit tests only, rake spec could not be done within the same travis worker
+# (ruby is installed on a PHP worker but .gemfile will be ignored)
+script: phpunit --coverage-text --configuration phpunit_ci.xml
+
+# whitelist
+branches:
+  only:
+    - master
+    - travis
+    - spec

--- a/phpunit_ci.xml.dist
+++ b/phpunit_ci.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="false"
+    convertNoticesToExceptions="false"
+    convertWarningsToExceptions="false"
+    processIsolation="false"
+    stopOnFailure="false"
+    stopOnError="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    syntaxCheck="false"
+    bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
I tried to get [RSpec](http://rspec-puppet.com/) running for the generated manifests and wanted to let [Travis](https://travis-ci.org/) test the results + PHPUnit test suite. However it is not possible to do that on Travis because a Travis worker is bound to one language. In our case we would need a PHP and a Ruby Environment (for RSpec).

I do not know if I get something useful running with RSpec but we could use Travis for the [PHPUnit test suite](http://about.travis-ci.org/docs/user/languages/php/) anyway.

If you allow this integration you have to:
- go to https://travis-ci.org and signup with your Github Account
- let Travis sync your repositories
- enable puphpet/puphpet for Travis
- enable Travis Hook here on Github
- do the PR merge after all this stuff, this should trigger the first build

Demo run: https://travis-ci.org/frastel/Puphpet/builds/9000384
