### PR TITLE
The end of line after an endif tag are seem to be ignored in twig templates.

### DIFF
--- a/src/Puphpet/View/Vagrant/README.twig
+++ b/src/Puphpet/View/Vagrant/README.twig
@@ -4,9 +4,11 @@ Welcome to your custom Vagrant/Puppet setup powered by puPHPet
 The setup includes:
 -------------------
 * box:       {{ box.name }} {% if box.url is defined %}({{ box.url }}){% endif %}
+
 * webserver: {{ webserver }}
 * database:  {{ database }}
 * PHP:       PHP 5.{% if php.version == 'php55' %}5{% elseif php.version == 'php54' %}4{% else %}3{% endif %}
+
 
 Next steps:
 -----------


### PR DESCRIPTION
The result is missing end of lines in the generated README. This commit corect
that by adding a second end of line in the README template.
