### PR TITLE
fixed rackspace provider label

### DIFF
--- a/web/assets/css/style.css
+++ b/web/assets/css/style.css
@@ -176,6 +176,10 @@ code {
     content: 'Digital Ocean';
 }
 
+#vagrant .bs-example.rackspaceProvider:after {
+    content: 'Rackspace';
+}
+
 .tab-content {
     padding-top: 15px;
 }


### PR DESCRIPTION
just a small fix to make "rackspace" look in line with "digital ocean"
