### PR TITLE
Updated repositories for correct PHP 5.4 location

### DIFF
--- a/src/Puphpet/View/Front/Tabs/php.html.twig
+++ b/src/Puphpet/View/Front/Tabs/php.html.twig
@@ -27,7 +27,7 @@
 
             <p class="help-block">
                 Integration of PHP 5.4 and 5.5 is currently not supported natively by
-                given vagrant boxes and thus a <a href="https://launchpad.net/~ondrej/+archive/php5">PPA</a> has to be used.
+                given vagrant boxes and thus a <a href="https://launchpad.net/~ondrej/+archive/php5-oldstable">PPA</a> has to be used.
                 Things might not work properly in this case.
                 <br />
                 If you encounter any problems please skip back to PHP 5.3.

--- a/src/Puphpet/View/Vagrant/Modules/OS/ubuntu.pp.twig
+++ b/src/Puphpet/View/Vagrant/Modules/OS/ubuntu.pp.twig
@@ -1,7 +1,7 @@
 {% if php.version == 'php55' %}
     {% set php_ppa = 'ppa:ondrej/php5-experimental' %}
 {% elseif php.version == 'php54' %}
-    {% set php_ppa = 'ppa:ondrej/php5' %}
+    {% set php_ppa = 'ppa:ondrej/php5-oldstable' %}
 {% else %}
     {% set php_ppa = false %}
 {% endif %}


### PR DESCRIPTION
It would appear that the [ondrej/php5 ubuntu repository](https://launchpad.net/~ondrej/+archive/php5) has been upgraded to php 5.5.1-1 by default.

This breaks the UI option to specify your PHP version as 5.4. This PR sets the 5.4 radio button to select the [ondrej/php5-oldstable ubuntu repository](https://launchpad.net/~ondrej/+archive/php5-oldstable)

**_Note**_
Defaulting to ppa:ondrej/php5 breaks some other things unexpectedly when running 5.5.x
- For php5-fpm, configurations have been moved to /etc/php5/fpm. I'm unsure of the best way to fix this in src/Puphpet/View/Vagrant/Modules/php.pp.twig
- php5-memcached doesn't install correctly, it's unable to install the libmemcached10 dependency
