### PR TITLE
Lowercase puphpet.git allows quickstart to checkout properly.

### DIFF
--- a/src/Puphpet/Plugins/Puphpet/View/Vagrant/clone.pp.twig
+++ b/src/Puphpet/Plugins/Puphpet/View/Vagrant/clone.pp.twig
@@ -1,6 +1,6 @@
 git::repo { 'puphpet':
   path   => '/var/www/puphpet.dev/',
-  source => 'https://github.com/puphpet/Puphpet.git'
+  source => 'https://github.com/puphpet/puphpet.git'
 }
 
 composer::run { 'puphpet':


### PR DESCRIPTION
Using Puphpet.git freaked out on me.
