### PR TITLE
Fix the FastCGI configuration for phpMyAdmin

### DIFF
--- a/src/Puphpet/View/Vagrant/Modules/mysql.pp.twig
+++ b/src/Puphpet/View/Vagrant/Modules/mysql.pp.twig
@@ -47,7 +47,7 @@ nginx::resource::location { "phpmyadmin-php":
     'fastcgi_param'           => 'PATH_INFO $fastcgi_path_info',
     'fastcgi_param '          => 'PATH_TRANSLATED $document_root$fastcgi_path_info',
     'fastcgi_param  '         => 'SCRIPT_FILENAME $document_root$fastcgi_script_name',
-    'fastcgi_pass'            => 'unix:/var/run/php5-fpm.sock',
+    'fastcgi_pass'            => '{{ php.version == 'php53'? '127.0.0.1:9000' :'unix:/var/run/php5-fpm.sock' }}',
     'fastcgi_index'           => 'index.php',
     'include'                 => 'fastcgi_params'
   },


### PR DESCRIPTION
PHP 5.4+ uses a socket to talk to PHP FPM while 5.3 is using an address.
