### PR TITLE
fixed digital ocean Vagrantfile

### DIFF
--- a/src/Puphpet/View/Vagrant/Vagrantfile/digitalocean.twig
+++ b/src/Puphpet/View/Vagrant/Vagrantfile/digitalocean.twig
@@ -1,9 +1,10 @@
 Vagrant.configure('2') do |config|
-  config.ssh.private_key_path = '{{ box.private_key }}'
-  config.ssh.username = 'vagrant'
-  config.vm.box = 'digital_ocean'
 
-  config.vm.provider :digital_ocean do |provider|
+  config.vm.provider :digital_ocean do |provider, override|
+    override.ssh.private_key_path = '~/.ssh/id_rsa'
+    override.vm.box = 'digital_ocean'
+    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+
     provider.client_id = '{{ box.client_id }}'
     provider.api_key = '{{ box.api_key }}'
     provider.image = '{{ box.image }}'


### PR DESCRIPTION
The current digital ocean Vagrantfile didn't work for me. I updated it and ran the phpunit tests and everything still passes. However, I was unable to actually create a manifest and test it with digital ocean locally. I attempted both the quickstart and just cloning the app. I got PuPHPet running but every time i tried to create "Create My Manifest!" i got the following: 

( ! ) Warning: filemtime(): stat failed for /tmp/5237df48ef15d8N7TML.zip in /var/www/puphpet.dev/src/Puphpet/Controller/Front.php on line 106
Call Stack
-#  Time    Memory  Function    Location
1   0.0012  292448  {main}( )   ../index.php:0
2   0.4098  2569888 Silex\Application->run( )   ../index.php:6
3   0.4387  3035120 Silex\Application->handle( )    ../Application.php:481
4   0.4515  3131256 Symfony\Component\HttpKernel\HttpKernel->handle( )  ../Application.php:504
5   0.4515  3131320 Symfony\Component\HttpKernel\HttpKernel->handleRaw( )   ../HttpKernel.php:73
6   0.4877  3336688 call_user_func_array ( )    ../HttpKernel.php:129
7   0.4877  3337112 Puphpet\Controller\Front->createAction( )   ../HttpKernel.php:129
8   4.5453  6871056 filemtime ( )   ../Front.php:106
