### PR TITLE
Update jfryman/puppet-nginx dependency to include $index_files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "example42/puppet-php":             "dev-master#3465b6d",
         "frastel/puppet-phpmyadmin":        "dev-master#b66963c",
         "frastel/puppet-symfony":           "dev-master#6b83915",
-        "jfryman/puppet-nginx":             "dev-master#4419300",
+        "jfryman/puppet-nginx":             "dev-master#04c5417",
         "puppetlabs/puppetlabs-mysql":      "dev-master#3205b83ac8",
         "puppetlabs/puppetlabs-apt":        "1.1.0",
         "puppetlabs/puppetlabs-postgresql": "2.2.1",


### PR DESCRIPTION
This puphpet interface to configure properly projects which don't use
index.php as the entry point to the application. An example is Symfony2

Reference commit: https://github.com/jfryman/puppet-nginx/commit/04c541

**Note:** I couldn't set up the vagrant box for puphpet to run the tests, and as such i'm not sure if this breaks anything.
