### PR TITLE
Enable sidebar Scrollspy functionality.

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/front/index.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/index.html.twig
@@ -69,4 +69,12 @@
     </div>
 
 </div>
+
+{% endblock %}
+
+{% block footerJs %}
+{{ parent() }}
+<script>
+  $('body').scrollspy({target: '#nav-sidebar', offset: 385});
+</script>
 {% endblock %}

--- a/src/Puphpet/MainBundle/Resources/views/front/sideMenu.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/sideMenu.html.twig
@@ -1,5 +1,5 @@
 <div class="col-sm-3 hidden-xs">
-    <div class="nav" data-spy="affix" data-offset-top="200" role="complementary">
+    <div class="nav" data-spy="affix" data-offset-top="200" role="complementary" id="nav-sidebar">
         <ul class="nav">
             <li><a href="#vagrantfile">Vagrantfile</a></li>
             <li><a href="#server">Server Basics</a></li>

--- a/web/assets/css/style.css
+++ b/web/assets/css/style.css
@@ -100,6 +100,15 @@ div.navbar {
 }
 
 /*
+ * Side Menu
+ */
+
+div.nav > ul.nav > li.active {
+    border-left: 3px solid #4C9BD8;
+    background-color: #eee;
+}
+
+/*
  * Footer
  */
 footer .img-thumbnail img {


### PR DESCRIPTION
This works on my test environment, but I had to pass a worrisomely large offset in order to get all of the sidebar elements to highlight once scrolling took place. This also causes the natural tick-point in Scrollspy to occur at a different position than one might expect. 
