### PR TITLE
Replaced $host with $grant #212

### DIFF
--- a/src/Puphpet/Extension/PostgresqlBundle/Resources/views/manifest/Postgresql.pp.twig
+++ b/src/Puphpet/Extension/PostgresqlBundle/Resources/views/manifest/Postgresql.pp.twig
@@ -28,7 +28,7 @@ define postgresql_db (
   $grant,
   $sql_file = false
 ) {
-  if $name == '' or $user == '' or $password == '' or $host == '' {
+  if $name == '' or $user == '' or $password == '' or $grant == '' {
     fail( 'PostgreSQL DB requires that name, user, password and grant be set. Please check your settings!' )
   }
 


### PR DESCRIPTION
Looks like a copy/paste mistake. Postgres has no $host configuration but a $grant configuration 
