### PR TITLE
Include NTP in the ServerBundle

### DIFF
--- a/src/Puphpet/Extension/ServerBundle/Configure.php
+++ b/src/Puphpet/Extension/ServerBundle/Configure.php
@@ -17,6 +17,7 @@ class Configure extends Extension\ExtensionAbstract
         'concat' => ":git => 'git://github.com/puppetlabs/puppetlabs-concat.git'",
         'apt'    => ":git => 'git://github.com/puppetlabs/puppetlabs-apt.git'",
         'git'    => ":git => 'git://github.com/nesi/puppet-git.git'",
+        'ntp'    => ":git => 'git://github.com/puppetlabs/puppetlabs-ntp.git'",
     ];
 
     /**

--- a/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
+++ b/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
@@ -4,6 +4,10 @@ if $server_values == undef {
   $server_values = hiera('server', false)
 }
 
+# Ensure the time is accurate, reducing the possibilities of apt repositories
+# failing for invalid certificates
+include '::ntp'
+
 group { 'puppet': ensure => present }
 Exec { path => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ] }
 File { owner => 0, group => 0, mode => 0644 }


### PR DESCRIPTION
Including NTP will ensure the time is correct, reducing the chances of
invalid certificate errors, and also reducing the chances of third
party APIs rejecting requests.
