### PR TITLE
removed hardcoding of extensions by introducing compiler pass for them

### DIFF
--- a/src/Puphpet/Extension/ApacheBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/ApacheBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\ApacheBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "webserver", priority: 290 }
 
     puphpet.extension.apache.front_controller:
         class: Puphpet\Extension\ApacheBundle\Controller\FrontController

--- a/src/Puphpet/Extension/MysqlBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\MysqlBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "database", priority: 190 }
 
     puphpet.extension.mysql.front_controller:
         class: Puphpet\Extension\MysqlBundle\Controller\FrontController

--- a/src/Puphpet/Extension/NginxBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/NginxBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\NginxBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "webserver", priority: 270 }
 
     puphpet.extension.nginx.front_controller:
         class: Puphpet\Extension\NginxBundle\Controller\FrontController

--- a/src/Puphpet/Extension/PhpBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/PhpBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\PhpBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, priority: 250 }
 
     puphpet.extension.php.front_controller:
         class: Puphpet\Extension\PhpBundle\Controller\FrontController

--- a/src/Puphpet/Extension/PostgresqlBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/PostgresqlBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\PostgresqlBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "database", priority: 170 }
 
     puphpet.extension.postgresql.front_controller:
         class: Puphpet\Extension\PostgresqlBundle\Controller\FrontController

--- a/src/Puphpet/Extension/ServerBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/ServerBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\ServerBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, priority: 310 }
 
     puphpet.extension.server.front_controller:
         class: Puphpet\Extension\ServerBundle\Controller\FrontController

--- a/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\VagrantfileAwsBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "vagrantfile", priority: 330 }
 
     puphpet.extension.vagrantfile.aws.front_controller:
         class: Puphpet\Extension\VagrantfileAwsBundle\Controller\FrontController

--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\VagrantfileDigitalOceanBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "vagrantfile", priority: 370 }
 
     puphpet.extension.vagrantfile.digital_ocean.front_controller:
         class: Puphpet\Extension\VagrantfileDigitalOceanBundle\Controller\FrontController

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\VagrantfileLocalBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "vagrantfile", priority: 390 }
 
     puphpet.extension.vagrantfile.local.front_controller:
         class: Puphpet\Extension\VagrantfileLocalBundle\Controller\FrontController

--- a/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\VagrantfileRackspaceBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, group: "vagrantfile", priority: 350 }
 
     puphpet.extension.vagrantfile.rackspace.front_controller:
         class: Puphpet\Extension\VagrantfileRackspaceBundle\Controller\FrontController

--- a/src/Puphpet/Extension/XdebugBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/XdebugBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\XdebugBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, priority: 230 }
 
     puphpet.extension.xdebug.front_controller:
         class: Puphpet\Extension\XdebugBundle\Controller\FrontController

--- a/src/Puphpet/Extension/XhprofBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/XhprofBundle/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
         class: Puphpet\Extension\XhprofBundle\Configure
         arguments:
             - "@service_container"
+        tags:
+            - { name: puphpet.extension, priority: 210 }
 
     puphpet.extension.xhprof.front_controller:
         class: Puphpet\Extension\XhprofBundle\Controller\FrontController

--- a/src/Puphpet/MainBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Puphpet/MainBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Puphpet\MainBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ExtensionPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $manager = $container->getDefinition('puphpet.extension.manager');
+
+        $extensions = [];
+
+        // find all extensions by tag "puphpet.extension" and map them to the tmp priority list
+        foreach ($container->findTaggedServiceIds('puphpet.extension') as $id => $attributes) {
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $group = isset($attributes[0]['group']) ? $attributes[0]['group'] : false;
+
+            if ($group) {
+                $extensions[$priority][] = ['group' => $group, 'extension' => new Reference($id)];
+            } else {
+                $extensions[$priority][] = new Reference($id);
+            }
+        }
+
+        // priority list is sorted now so priority defined in the tags is taken to effect
+        // services with a higher prio will be added first (100>50)
+        krsort($extensions);
+
+        // sorted extensions could be added to extension manager now either with "addExtensionToGroup"
+        // or "addExtension"
+        foreach ($extensions as $extensionRow) {
+            foreach ($extensionRow as $extension) {
+                if (is_array($extension)) {
+                    $manager->addMethodCall('addExtensionToGroup', array($extension['group'], $extension['extension']));
+                } else {
+                    $manager->addMethodCall('addExtension', array($extension));
+                }
+            }
+        }
+    }
+}

--- a/src/Puphpet/MainBundle/PuphpetMainBundle.php
+++ b/src/Puphpet/MainBundle/PuphpetMainBundle.php
@@ -2,8 +2,14 @@
 
 namespace Puphpet\MainBundle;
 
+use Puphpet\MainBundle\DependencyInjection\Compiler\ExtensionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PuphpetMainBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ExtensionPass());
+    }
 }

--- a/src/Puphpet/MainBundle/Resources/config/services.yml
+++ b/src/Puphpet/MainBundle/Resources/config/services.yml
@@ -9,22 +9,6 @@ services:
         class: Puphpet\MainBundle\Extension\Manager
         arguments:
             - "@service_container"
-        calls:
-        # vagrantfile group
-            - [ addExtensionToGroup, [ 'vagrantfile', @puphpet.extension.vagrantfile.local.configure ] ]
-            - [ addExtensionToGroup, [ 'vagrantfile', @puphpet.extension.vagrantfile.digital_ocean.configure ] ]
-            - [ addExtensionToGroup, [ 'vagrantfile', @puphpet.extension.vagrantfile.rackspace.configure ] ]
-            - [ addExtensionToGroup, [ 'vagrantfile', @puphpet.extension.vagrantfile.aws.configure ] ]
-            - [ addExtension, [ @puphpet.extension.server.configure ] ]
-        # webserver group
-            - [ addExtensionToGroup, [ 'webserver', @puphpet.extension.apache.configure ] ]
-            - [ addExtensionToGroup, [ 'webserver', @puphpet.extension.nginx.configure ] ]
-            - [ addExtension, [ @puphpet.extension.php.configure ] ]
-            - [ addExtension, [ @puphpet.extension.xdebug.configure ] ]
-            - [ addExtension, [ @puphpet.extension.xhprof.configure ] ]
-        # database group
-            - [ addExtensionToGroup, [ 'database', @puphpet.extension.mysql.configure ] ]
-            - [ addExtensionToGroup, [ 'database', @puphpet.extension.postgresql.configure ] ]
 
     puphpet.twig.base_extension:
         class: Puphpet\MainBundle\Twig\BaseExtension

--- a/src/Puphpet/MainBundle/Resources/doc/index.rst
+++ b/src/Puphpet/MainBundle/Resources/doc/index.rst
@@ -1,0 +1,37 @@
+=================
+Adding Extensions
+=================
+
+All you need to do is to tag your extension service with the **puphpet.extension** tag.
+
+- An optional priority attribute could be used for well-defined ordering how the extensions are loaded into the manager (default: 0). The higher the priority the sooner an extension will be added.
+- Besides if a **group** attribute is set, the **addExtensionToGroup** method will be triggered.
+
+**Examples:**
+
+::
+
+    #  same as $manager->addExtensionToGroup('vagrantfile', <service_id>)
+    tags:
+        - { name: puphpet.extension, group: "vagrantfile", priority: 190 }
+
+    #  same as $manager->addExtension(<service_id>)
+    tags:
+        - { name: puphpet.extension, priority: 250 }
+
+
+
+**Default Extension Ordering:**
+
+- 390: vagrantfile, @puphpet.extension.vagrantfile.local.configure
+- 370: vagrantfile, @puphpet.extension.vagrantfile.digital_ocean.configure
+- 350: vagrantfile, @puphpet.extension.vagrantfile.rackspace.configure
+- 330: vagrantfile, @puphpet.extension.vagrantfile.aws.configure
+- 310: @puphpet.extension.server.configure
+- 290: webserver, @puphpet.extension.apache.configure
+- 270: webserver, puphpet.extension.nginx.configure
+- 250: @puphpet.extension.php.configure
+- 230: @puphpet.extension.xdebug.configure
+- 210: @puphpet.extension.xhprof.configure
+- 190: @puphpet.extension.mysql.configure
+- 170: @puphpet.extension.postgresql.configure

--- a/src/Puphpet/MainBundle/Tests/DependencyInjection/Compiler/ExtensionPassTest.php
+++ b/src/Puphpet/MainBundle/Tests/DependencyInjection/Compiler/ExtensionPassTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Puphpet\MainBundle\Tests\DependencyInjection\Compiler;
+
+use Puphpet\MainBundle\DependencyInjection\Compiler\ExtensionPass;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ExtensionPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        // mixed order, priority value is important
+        $tags = [
+            'extension_group_200' => [['name' => 'puphpet.extension', 'group' => 'foo', 'priority' => 200]],
+            'extension_group_400' => [['name' => 'puphpet.extension', 'group' => 'foo', 'priority' => 400]],
+            'extension_300'       => [['name' => 'puphpet.extension', 'priority' => 300]],
+            'extension_100'       => [['name' => 'puphpet.extension', 'priority' => 100]],
+        ];
+
+        // the manager definition should recieve 4 extensions
+        // 2 groups and 2 normal ones
+        $manager = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->setMethods(['addMethodCall'])
+            ->getMock();
+
+        $manager->expects($this->at(0))
+            ->method('addMethodCall')
+            ->with('addExtensionToGroup', ['foo', $this->buildReference('extension_group_400')]);
+
+        $manager->expects($this->at(1))
+            ->method('addMethodCall')
+            ->with('addExtension', [$this->buildReference('extension_300')]);
+
+        $manager->expects($this->at(2))
+            ->method('addMethodCall')
+            ->with('addExtensionToGroup', ['foo', $this->buildReference('extension_group_200')]);
+
+        $manager->expects($this->at(3))
+            ->method('addMethodCall')
+            ->with('addExtension', [$this->buildReference('extension_100')]);
+
+
+        // the ContainerBuilder has to return all tagged services
+        $container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(['findTaggedServiceIds', 'getDefinition'])
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('getDefinition')
+            ->will($this->returnValue($manager));
+
+        $container->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('puphpet.extension')
+            ->will($this->returnValue($tags));
+
+
+        $pass = new ExtensionPass();
+        $pass->process($container);
+    }
+
+    private function buildReference($id)
+    {
+        // couldn't be mocked properly :/ otherwise comparison will fail
+        return new Reference($id);
+    }
+}


### PR DESCRIPTION
In order to use extensions really as extensions the hardcoding of `Extension\Manager` populating has to be removed.
For this purpose I created a compiler pass `Puphpet\MainBundle\DependencyInjection\Compiler\ExtensionPass`. [Compiler passes](http://symfony.com/doc/current/components/dependency_injection/tags.html) could be used to "magically" populate services with stuff from vendor locations during building of the container.

That means during building the container the compiler pass will search for all services tagged with `puphpet.extension` and add them to the manager. In this way an extension could be added without having the need of modifying the original manager definition anymore.

Example:

```
services:
    puphpet.extension.mysql.configure:
        class: Puphpet\Extension\MysqlBundle\Configure
        arguments:
            - "@service_container"
        tags:
            - { name: puphpet.extension, group: "database", priority: 190 }
```

Have a look at the `Resources/doc/index.rst` for more information (e.g the priority).

Compiler passes are really great and are one reason why I wanted to the migration to Symfony2 :)
