### PR TITLE
replaced debug switches in twig with native supported debug value

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/front/template.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/template.html.twig
@@ -68,7 +68,7 @@
                 <p>A simple GUI to set up virtual machines for <strike>PHP</strike> <strong>Web</strong> development.</p>
             </div>
             <div class="col-sm-3 col-xs-6">
-                {% if not constant('DEBUG') %}
+                {% if not app.debug %}
                     {% include 'PuphpetMainBundle:front:carbonAds.html.twig' %}
                 {% endif %}
             </div>
@@ -119,8 +119,8 @@
         <script src="/assets/js/custom.js"></script>
     {% endblock footerJs %}
 
-    {% if not constant('DEBUG') %}
-        <script>
+    {% if not app.debug %}
+        <script type="text/javascript">
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/web/app.php
+++ b/web/app.php
@@ -2,8 +2,6 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-define('DEBUG', false);
-
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
 $loader->register(true);

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -7,8 +7,6 @@ if (getenv('APP_ENV') !== 'dev') {
     exit;
 }
 
-define('DEBUG', true);
-
 error_reporting(E_ALL);
 ini_set('display_errors', '1');
 ini_set('opcache.enable', '0');


### PR DESCRIPTION
There is no need to add an additional debug value for twig. 

The value of kernel.debug (the second argument received by AppKernel) triggers the twig.debug value.
If you want to define the twig debug value than you could do this in the configs with:

```
# app/config/config_dev.yml
twig:
    debug: false
```

Besides Twig gets `app.debug` as global variable in Symfony. So one could use this value in all used templates.
