### PR TITLE
replaced rendering of contributors from js to real sub-request

### DIFF
--- a/src/Puphpet/MainBundle/CacheWarmer/ContributorsCacheWarmer.php
+++ b/src/Puphpet/MainBundle/CacheWarmer/ContributorsCacheWarmer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Puphpet\MainBundle\CacheWarmer;
+
+use Puphpet\MainBundle\Filesystem\Filesystem;
+use Puphpet\MainBundle\Repository\ContributorRepository;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class ContributorsCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * @var ContributorRepository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @param ContributorRepository $repository
+     * @param string                $filename
+     * @param Filesystem            $filesystem
+     */
+    public function __construct(ContributorRepository $repository, $filename, Filesystem $filesystem)
+    {
+        $this->repository = $repository;
+        $this->filename = $filename;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Checks whether this warmer is optional or not.
+     *
+     * Optional warmers can be ignored on certain conditions.
+     *
+     * A warmer should return true if the cache can be
+     * generated incrementally and on-demand.
+     *
+     * @return Boolean true if the warmer is optional, false otherwise
+     */
+    public function isOptional()
+    {
+        return false;
+    }
+
+    /**
+     * Warms up the cache.
+     *
+     * @param string $cacheDir The cache directory
+     */
+    public function warmUp($cacheDir)
+    {
+        $contributors = $this->repository->findAll();
+
+        // only cache valid content and no reponses with errors or whatever
+        if (count($contributors) && !isset($contributors['message'])) {
+            $this->filesystem->dumpFile($cacheDir . '/' . $this->filename, json_encode($contributors));
+        }
+    }
+}

--- a/src/Puphpet/MainBundle/Controller/FrontController.php
+++ b/src/Puphpet/MainBundle/Controller/FrontController.php
@@ -92,16 +92,10 @@ class FrontController extends Controller
 
     public function githubContributorsAction(Request $request)
     {
-        if ($this->container->has('profiler')) {
-            $this->container->get('profiler')->disable();
-        }
+        $contributors = $this->get('puphpet.repository.contributor')->findAll();
 
-        $contributors = $request->get('contributors');
-
-        $foo = $this->render('PuphpetMainBundle:front:github-contributors.html.twig', [
+        return $this->render('PuphpetMainBundle:front:github-contributors.html.twig', [
             'contributors' => $contributors
         ]);
-
-        return $foo;
     }
 }

--- a/src/Puphpet/MainBundle/DependencyInjection/PuphpetMainExtension.php
+++ b/src/Puphpet/MainBundle/DependencyInjection/PuphpetMainExtension.php
@@ -24,5 +24,6 @@ class PuphpetMainExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('contributors.yml');
     }
 }

--- a/src/Puphpet/MainBundle/Filesystem/Filesystem.php
+++ b/src/Puphpet/MainBundle/Filesystem/Filesystem.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Puphpet\MainBundle\Filesystem;
+
+use Symfony\Component\Filesystem\Filesystem as BaseFileystem;
+
+class Filesystem extends BaseFileystem
+{
+    /**
+     * Reads file and returns its content
+     *
+     * @param string $filepath
+     *
+     * @return string|bool
+     */
+    public function readFile($filepath)
+    {
+        return file_get_contents($filepath);
+    }
+}

--- a/src/Puphpet/MainBundle/Repository/CachedContributorRepository.php
+++ b/src/Puphpet/MainBundle/Repository/CachedContributorRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Puphpet\MainBundle\Repository;
+
+use Puphpet\MainBundle\Filesystem\Filesystem;
+
+/**
+ * Cache Proxy for ContributorRepository
+ */
+class CachedContributorRepository
+{
+
+    private $cacheDir;
+    private $filename;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var ContributorRepository
+     */
+    private $repository;
+
+    /**
+     * @param string                $cacheDir   the kernel.cache_dir
+     * @param string                $filename   the cache filename
+     * @param Filesystem            $filesystem
+     * @param ContributorRepository $repository the repository as fallback if cache does not exist
+     */
+    public function __construct($cacheDir, $filename, Filesystem $filesystem, ContributorRepository $repository)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->filename = $filename;
+        $this->filesystem = $filesystem;
+        $this->repository = $repository;
+    }
+
+    /**
+     * @return array|mixed
+     */
+    public function findAll()
+    {
+        $content = $this->getCachedContent();
+        // cached content does exist? if yes, unserialize it and we are done
+        if ($content) {
+            return json_decode($content, true);
+        }
+
+        // oh, cache does not exist.. trigger the fallback
+        return $this->repository->findAll();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getCachedContent()
+    {
+        return $this->filesystem->readFile($this->cacheDir . '/' . $this->filename);
+    }
+}

--- a/src/Puphpet/MainBundle/Repository/ContributorRepository.php
+++ b/src/Puphpet/MainBundle/Repository/ContributorRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Puphpet\MainBundle\Repository;
+
+class ContributorRepository
+{
+    private $targetUrl;
+
+    /**
+     * @param string $targetUrl the github target url providing all contributors
+     */
+    public function __construct($targetUrl)
+    {
+        $this->targetUrl = $targetUrl;
+    }
+
+    /**
+     * Returns a list of all contributors
+     *
+     * @return array
+     */
+    public function findAll()
+    {
+        return json_decode($this->get($this->targetUrl), true);
+    }
+
+    /**
+     * Does a simple GET request on given url
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    protected function get($url)
+    {
+        // curl could be replaced by any high level transport layer like Buzz or Guzzle
+
+        // create a new cURL resource
+        $ch = curl_init();
+
+        // set URL and other appropriate options
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        // grab URL and pass it to the browser
+        $response = curl_exec($ch);
+
+        // close cURL resource, and free up system resources
+        curl_close($ch);
+
+        return $response;
+    }
+}

--- a/src/Puphpet/MainBundle/Resources/config/contributors.yml
+++ b/src/Puphpet/MainBundle/Resources/config/contributors.yml
@@ -1,0 +1,43 @@
+parameters:
+    puphpet.contributors.file: "contributors.json"
+
+services:
+
+    puphpet.filesystem:
+        class: Puphpet\MainBundle\Filesystem\Filesystem
+        public: false
+
+    # gets the contributors from github api
+    # should not be called from outside
+    puphpet.repository.contributor.curl:
+        class: Puphpet\MainBundle\Repository\ContributorRepository
+        public: false
+        arguments:
+            - "https://api.github.com/repos/puphpet/puphpet/contributors"
+
+    # caches returned github contributors
+    puphpet.cache_warmer.contributors:
+        class: Puphpet\MainBundle\CacheWarmer\ContributorsCacheWarmer
+        public: false
+        arguments:
+            - "@puphpet.repository.contributor.curl"
+            - "%puphpet.contributors.file%"
+            - "@puphpet.filesystem"
+        tags:
+            - { name: "kernel.cache_warmer" }
+
+    # proxy for the real repository
+    # should also not be used from outside
+    puphpet.repository.contributor.cached:
+        class: Puphpet\MainBundle\Repository\CachedContributorRepository
+        public: false
+        arguments:
+            - "%kernel.cache_dir%"
+            - "%puphpet.contributors.file%"
+            - "@puphpet.filesystem"
+            - "@puphpet.repository.contributor.curl"
+
+    # via this alias we make the contributor service available to the outside
+    # and hide that we are using a caching layer
+    puphpet.repository.contributor:
+        alias: puphpet.repository.contributor.cached

--- a/src/Puphpet/MainBundle/Resources/views/front/template.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/template.html.twig
@@ -106,7 +106,7 @@
 
                 <h4>Made possible thanks to contributions by</h4>
 
-                <div id="contributors"></div>
+                <div id="contributors">{{ render(controller('PuphpetMainBundle:Front:githubContributors')) }}</div>
             </div>
         </div>
     </div>

--- a/src/Puphpet/MainBundle/Tests/CacheWarmer/ContributorsCacheWarmerTest.php
+++ b/src/Puphpet/MainBundle/Tests/CacheWarmer/ContributorsCacheWarmerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Puphpet\MainBundle\Tests\DependencyInjection\Compiler;
+
+use Puphpet\MainBundle\CacheWarmer\ContributorsCacheWarmer;
+
+class ContributorsCacheWarmerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWarmUp()
+    {
+        $cacheDir = '/foo';
+        $filename = 'bar';
+        $contributors = ['foo' => 'bar'];
+        $serializedContributors = '{"foo":"bar"}';
+
+        $repository = $this->getMockBuilder('\Puphpet\MainBundle\Repository\ContributorRepository')
+            ->disableOriginalConstructor()
+            ->setMethods(['findAll'])
+            ->getMock();
+
+        $repository->expects($this->once())
+            ->method('findAll')
+            ->will($this->returnValue($contributors));
+
+        $filesystem = $this->getMockBuilder('\Puphpet\MainBundle\Filesystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->setMethods(['dumpFile'])
+            ->getMock();
+
+        $filesystem->expects($this->once())
+            ->method('dumpFile')
+            ->with('/foo/bar', $serializedContributors);
+
+        $warmer = new ContributorsCacheWarmer($repository, $filename, $filesystem);
+        $warmer->warmUp($cacheDir);
+    }
+}

--- a/src/Puphpet/MainBundle/Tests/Repository/CachedContributorRepositoryTest.php
+++ b/src/Puphpet/MainBundle/Tests/Repository/CachedContributorRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Puphpet\MainBundle\Tests\DependencyInjection\Compiler;
+
+use Puphpet\MainBundle\Repository\CachedContributorRepository;
+
+class CachedContributorRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testFindAllOnCacheHit()
+    {
+        $cacheDir = '/foo';
+        $filename = 'bar';
+        $serializedContributors = '{"foo":"bar"}';
+
+        $filesystem = $this->getMockBuilder('\Puphpet\MainBundle\Filesystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->setMethods(['readFile'])
+            ->getMock();
+
+        // simulated cache hit
+        $filesystem->expects($this->once())
+            ->method('readFile')
+            ->with('/foo/bar')
+            ->will($this->returnValue($serializedContributors));
+
+        // callback repository should never be called
+        $repository = $this->getMockBuilder('\Puphpet\MainBundle\Repository\ContributorRepository')
+            ->disableOriginalConstructor()
+            ->setMethods(['findAll'])
+            ->getMock();
+
+        $repository->expects($this->never())
+            ->method('findAll');
+
+        $cachedRepository = new CachedContributorRepository($cacheDir, $filename, $filesystem, $repository);
+        $result = $cachedRepository->findAll();
+
+        $this->assertEquals(['foo' => 'bar'], $result);
+    }
+
+    public function testFindAllOnCacheMiss()
+    {
+        $cacheDir = '/foo';
+        $filename = 'bar';
+        $serializedContributors = false;
+
+        $filesystem = $this->getMockBuilder('\Puphpet\MainBundle\Filesystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->setMethods(['readFile'])
+            ->getMock();
+
+        // simulated cache hit
+        $filesystem->expects($this->once())
+            ->method('readFile')
+            ->with('/foo/bar')
+            ->will($this->returnValue($serializedContributors));
+
+        // callback repository should never be called
+        $repository = $this->getMockBuilder('\Puphpet\MainBundle\Repository\ContributorRepository')
+            ->disableOriginalConstructor()
+            ->setMethods(['findAll'])
+            ->getMock();
+
+        $repository->expects($this->once())
+            ->method('findAll')
+            ->will($this->returnValue(['foo' => 'bar']));
+
+        $cachedRepository = new CachedContributorRepository($cacheDir, $filename, $filesystem, $repository);
+        $result = $cachedRepository->findAll();
+
+        $this->assertEquals(['foo' => 'bar'], $result);
+    }
+}

--- a/web/assets/js/custom.js
+++ b/web/assets/js/custom.js
@@ -339,17 +339,6 @@ PUPHPET.enableClickedTabElement = function() {
 };
 
 /**
- * Display the information about PuPHPet's beloved contributors!
- */
-PUPHPET.githubContributors = function() {
-    $.get('https://api.github.com/repos/puphpet/puphpet/contributors', function(githubResponse) {
-        $.post('/github-contributors', { contributors: githubResponse }, function(response) {
-            $('#contributors').html(response);
-        });
-    });
-};
-
-/**
  * Allows user to drag and drop a pre-generated yaml file containing
  * their VMs configuration.
  */
@@ -455,7 +444,6 @@ $(document).ready(function() {
     PUPHPET.delRepeatableElement();
     PUPHPET.disableInactiveTabElements();
     PUPHPET.enableClickedTabElement();
-    PUPHPET.githubContributors();
     PUPHPET.uploadConfig();
     PUPHPET.sidebar();
 });


### PR DESCRIPTION
Another PR with does some cosmetics.
I have seen that the contributions area is filled from a mix of js and an additional Symfony controller. 
The GET request to GitHub's API is done on every PuPHPet request and I wanted to cache it. Therefore I have implemented a CacheWarmer which fetches the contents from the API and caches it in one cache file `%kernel.cache_dir/contributors.json%`. An every `cache:clear` the list is updated now.
Within the template the contributors area is filled via a real sub-request. A new Repository class tries to get the contents from the cache first. If nothing could be found it does a fallback on the real API request service.

_Attention:_
I had to install `php5-curl` first on my fresh box as I use curl for fetching the data from GitHub. Please go sure that curl is also installed on your machines. 
