### PR TITLE
security is not really needed in the project - but cleanup done anyway

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,4 +12,7 @@ parameters:
     mailer_password:   ~
 
     locale:            en
-    secret:            ThisTokenIsNotSoSecretChangeIt
+    secret:            ThisTokenIsNotSoSecretButItsOpenSourceAnyway
+
+    user_password:     57f3d5fdf38bafeb55fe9483e9b0049dec1df872
+    admin_password:    433a9b7b0e9a8bff8b68a812be4fc7e4d70a3d44

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,6 +1,9 @@
 security:
     encoders:
-        Symfony\Component\Security\Core\User\User: plaintext
+        Symfony\Component\Security\Core\User\User:
+            algorithm: sha1
+            iterations: 2
+            encode_as_base64: false
 
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER
@@ -10,30 +13,26 @@ security:
         in_memory:
             memory:
                 users:
-                    user:  { password: userpass, roles: [ 'ROLE_USER' ] }
-                    admin: { password: adminpass, roles: [ 'ROLE_ADMIN' ] }
+                    user:  { password: '%user_password%', roles: [ 'ROLE_USER' ] }
+                    admin: { password: '%admin_password%', roles: [ 'ROLE_ADMIN' ] }
 
     firewalls:
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
-        login:
-            pattern:  ^/demo/secured/login$
-            security: false
+#        login:
+#            pattern:  ^/login$
+#            security: false
 
-        secured_area:
-            pattern:    ^/demo/secured/
-            form_login:
-                check_path: _security_check
-                login_path: _demo_login
-            logout:
-                path:   _demo_logout
-                target: _demo
-            #anonymous: ~
-            #http_basic:
-            #    realm: "Secured Demo Area"
+        main:
+            pattern:    ^/
+            anonymous:  ~
 
+    # we currently need no access control at all in the project
     access_control:
-        - { path: ^/demo/secured/hello/admin/, roles: ROLE_ADMIN }
+        # would require https for everything (properly not very useful on dev machines):
+        #- { path: ^/.*, role: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }
+
+        #- { path: ^/demo/secured/hello/admin/, roles: ROLE_ADMIN }
         #- { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }


### PR DESCRIPTION
Minor PR

These changes are not needed for the project but it's however a good practise to get rid of plain encoders and hardcoded passwords in the security.yml. For demo purposes I have changed the content a little bit. Passwords would be fetched from new parameters in databases.yml. Besides the demo stuff was removed (commented out).
