### PR TITLE
Added mbstring extension to the available extensions list

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/PhpBundle/Resources/config/available.yml
@@ -16,6 +16,7 @@ available_modules:
         - intl
         - ldap
         - mapscript
+        - mbstring
         - mcrypt
         - memcache
         - memcached


### PR DESCRIPTION
Mbstring is required to work with Symfony2 framework,
so I just added it to the available extensions list.

If this need a particular test to be merged, let me know.
