### PR TITLE
Added support for arrays in php ini configuration

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
+++ b/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
@@ -83,11 +83,22 @@ if count($php_values['modules']['pecl']) > 0 {
 }
 if count($php_values['ini']) > 0 {
   each( $php_values['ini'] ) |$key, $value| {
-    puphpet::ini { $key:
-      entry       => "CUSTOM/${key}",
-      value       => $value,
-      php_version => $php_values['version'],
-      webserver   => $php_webserver_service
+    if is_array($value) {
+      each( $php_values['ini'][$key] ) |$innerkey, $innervalue| {
+        puphpet::ini { "${key}_${innerkey}":
+          entry       => "CUSTOM_${innerkey}/${key}",
+          value       => $innervalue,
+          php_version => $php_values['version'],
+          webserver   => $php_webserver_service
+        }
+      }
+    } else {
+      puphpet::ini { $key:
+        entry       => "CUSTOM/${key}",
+        value       => $value,
+        php_version => $php_values['version'],
+        webserver   => $php_webserver_service
+      }
     }
   }
 


### PR DESCRIPTION
Currently arrays are merged to a string for php-ini configuration in the hieradata yaml file:

Example configuration:

``` YAML
php:
    ini:
        display_errors: On
        error_reporting: '-1'
        extension:
            - 'mongo.so'
            - 'zmq.so'
```

The current template will concatenate the values and create a php ini configuration like this:

``` BASH
[CUSTOM]
error_reporting=-1
display_errors=true
extension=mongo.sozmq.zo
```

This new template will interpret the array and create a config like this:

``` BASH
[CUSTOM]
error_reporting=-1
display_errors=true
[CUSTOM_1]
extension=zmq.so
[CUSTOM_0]
extension=mongo.so
```
