### PR TITLE
added possibility to customize extension data by global config with hostname as showcase

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/EventListener/HostnameMixinListener.php
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/EventListener/HostnameMixinListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Puphpet\Extension\VagrantfileLocalBundle\EventListener;
+
+use Puphpet\MainBundle\EventListener\MixinConfigurationListener;
+
+class HostnameMixinListener extends MixinConfigurationListener
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports(array $configuration)
+    {
+        return (isset($configuration['apache']) || isset($configuration['nginx']));
+    }
+
+    /**
+     * Extracts the hostname/servername of the first vhost and takes this value
+     * for the box's hostname.
+     *
+     * {@inheritdoc}
+     */
+    protected function mixin(array $configuration, array $data)
+    {
+        $hostname = null;
+
+        if (isset($configuration['apache'])) {
+            $vhosts = $configuration['apache']['vhosts'];
+            $firstVhost = current($vhosts);
+            $hostname = $firstVhost['servername'];
+        } elseif (isset($configuration['nginx'])) {
+            $vhosts = $configuration['nginx']['vhosts'];
+            $firstVhost = current($vhosts);
+            $hostname = $firstVhost['servername'];
+        }
+
+        if ($hostname) {
+            $data['vm']['hostname'] = $hostname;
+        }
+
+        return $data;
+    }
+}

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/services.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/services.yml
@@ -15,3 +15,8 @@ services:
         class: Puphpet\Extension\VagrantfileLocalBundle\Controller\ManifestController
         calls:
             - [ setContainer, [@service_container] ]
+
+    puphpet.extension.vagrantfile.local.hostname_listener:
+        class: Puphpet\Extension\VagrantfileLocalBundle\EventListener\HostnameMixinListener
+        tags:
+            - { name: kernel.event_listener, event: configuration.extension.pre_bind, method: onPreBind }

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.pp.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.pp.twig
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "{{ data.vm.box }}"
   config.vm.box_url = "{{ data.vm.box_url|raw }}"
-{% if data.vm.hostname %}  config.vm.hostname = {{ data.vm.hostname }}{% endif %}
+{% if data.vm.hostname %}  config.vm.hostname = "{{ data.vm.hostname }}"{% endif %}
 
 {% if data.vm.network.private_network %}
   config.vm.network "private_network", ip: "{{ data.vm.network.private_network }}"

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Tests/Unit/EventListener/HostnameMixinListenerTest.php
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Tests/Unit/EventListener/HostnameMixinListenerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Puphpet\Tests\Unit\MainBundle\Extension;
+
+use Puphpet\Extension\VagrantfileLocalBundle\EventListener\HostnameMixinListener;
+use Puphpet\MainBundle\Event\ConfigurationEvent;
+
+class HostnameMixinListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideConfiguration
+     */
+    public function testMixin($configuration, $data, $expectedData)
+    {
+        $event = new ConfigurationEvent($configuration, $data);
+
+        $listener = new HostnameMixinListener();
+        $listener->onPreBind($event);
+
+        $resultData = $event->getData();
+        $this->assertEquals($expectedData, $resultData);
+    }
+
+    public function provideConfiguration()
+    {
+        // apache config ...
+        $configuration = [
+            'apache' => [
+                'vhosts' => [
+                    'random' => [
+                        'servername' => 'apache.example.com'
+                    ]
+                ]
+            ]
+        ];
+
+        $data = [
+            'foo' => 'bar',
+            'vm'  => [
+                'some' => 'thing',
+            ]
+        ];
+
+        $expectedData = [
+            'foo' => 'bar',
+            'vm'  => [
+                'some'     => 'thing',
+                'hostname' => 'apache.example.com'
+            ]
+        ];
+
+        $apacheConfig = [$configuration, $data, $expectedData];
+
+        // nginx config ...
+        $configuration = [
+            'nginx' => [
+                'vhosts' => [
+                    'random123' => [
+                        'servername' => 'nginx.example.com'
+                    ]
+                ]
+            ]
+        ];
+
+        $data = [
+            'foo' => 'bar',
+            'vm'  => [
+                'some' => 'thing',
+            ]
+        ];
+
+        $expectedData = [
+            'foo' => 'bar',
+            'vm'  => [
+                'some'     => 'thing',
+                'hostname' => 'nginx.example.com'
+            ]
+        ];
+        $nginxConfig = [$configuration, $data, $expectedData];
+
+        return [
+            $apacheConfig,
+            $nginxConfig,
+        ];
+    }
+}

--- a/src/Puphpet/MainBundle/Event/ConfigurationEvent.php
+++ b/src/Puphpet/MainBundle/Event/ConfigurationEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Puphpet\MainBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ConfigurationEvent extends Event
+{
+    /**
+     * @param array $configuration the complete and raw user configuration
+     * @param array $data          the user configuration data
+     */
+    public function __construct(array $configuration, array $data)
+    {
+        $this->configuration = $configuration;
+        $this->data = $data;
+    }
+
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+} 

--- a/src/Puphpet/MainBundle/Event/ConfigurationEvents.php
+++ b/src/Puphpet/MainBundle/Event/ConfigurationEvents.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Puphpet\MainBundle\Event;
+
+final class ConfigurationEvents
+{
+    /**
+     * Used just before user data is bound to an extension
+     */
+    const EXTENSION_PRE_BIND = 'configuration.extension.pre_bind';
+
+    private function __construct()
+    {
+    }
+} 

--- a/src/Puphpet/MainBundle/EventListener/MixinConfigurationListener.php
+++ b/src/Puphpet/MainBundle/EventListener/MixinConfigurationListener.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Puphpet\MainBundle\EventListener;
+
+use Puphpet\MainBundle\Event\ConfigurationEvent;
+
+abstract class MixinConfigurationListener
+{
+    public function onPreBind(ConfigurationEvent $event)
+    {
+        if ($this->supports($event->getConfiguration())) {
+            $newData = $this->mixin($event->getConfiguration(), $event->getData());
+            $event->setData($newData);
+        }
+    }
+
+    /**
+     * Whether the listener should run with given configuration
+     *
+     * @param array $configuration
+     *
+     * @return bool
+     */
+    abstract protected function supports(array $configuration);
+
+    /**
+     * Generates new user configuration data from given configuration.
+     * Useful if one extension needs configuration from another one.
+     *
+     * @param array $configuration
+     * @param array $data
+     *
+     * @return array
+     */
+    abstract protected function mixin(array $configuration, array $data);
+}

--- a/src/Puphpet/MainBundle/Resources/config/services.yml
+++ b/src/Puphpet/MainBundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ services:
     puphpet.extension.manager:
         class: Puphpet\MainBundle\Extension\Manager
         arguments:
+            - "@event_dispatcher"
             - "@service_container"
         calls:
         # vagrantfile group

--- a/src/Puphpet/MainBundle/Tests/Unit/MainBundle/Extension/ManagerTest.php
+++ b/src/Puphpet/MainBundle/Tests/Unit/MainBundle/Extension/ManagerTest.php
@@ -31,6 +31,12 @@ class ManagerTest extends Unit\TestExtensions
         return $mock;
     }
 
+    public function getEventDispatcherMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            ->getMockForAbstractClass();
+    }
+
     public function testAddExtensionToGroupSavesToGroupArray()
     {
         $extensionApache     = $this->getExtensionMock('apache');
@@ -38,7 +44,9 @@ class ManagerTest extends Unit\TestExtensions
         $extensionMySQL      = $this->getExtensionMock('mysql');
         $extensionPostgreSQL = $this->getExtensionMock('postgresql');
 
-        $manager = new Manager($this->container);
+        $eventDispatcher = $this->getEventDispatcherMock();
+
+        $manager = new Manager($eventDispatcher, $this->container);
 
         $manager->addExtensionToGroup('webserver', $extensionApache)
             ->addExtensionToGroup('webserver', $extensionNginx)
@@ -56,7 +64,9 @@ class ManagerTest extends Unit\TestExtensions
         $extensionApache = $this->getExtensionMock('apache');
         $extensionPHP    = $this->getExtensionMock('php');
 
-        $manager = new Manager($this->container);
+        $eventDispatcher = $this->getEventDispatcherMock();
+
+        $manager = new Manager($eventDispatcher, $this->container);
 
         $manager->addExtension($extensionPHP)
             ->addExtensionToGroup('webserver', $extensionApache);
@@ -69,7 +79,9 @@ class ManagerTest extends Unit\TestExtensions
     {
         $extensionPHP = $this->getExtensionMock('php');
 
-        $manager = new Manager($this->container);
+        $eventDispatcher = $this->getEventDispatcherMock();
+
+        $manager = new Manager($eventDispatcher, $this->container);
 
         $manager->addExtension($extensionPHP);
 


### PR DESCRIPTION
So far it is not possible to make something like suggested in #364. Here some config from one extension (apache or nginx extension) would be needed in some other extension (vagrant local). Sounds easy, but currently one extension has only access to its own configuration and [could not be modified by global configuration](https://github.com/puphpet/puphpet/blob/master/src/Puphpet/MainBundle/Extension/Manager.php#L236).

I added an event which could be used for manipulating the extension data before it is bound to the extension itself. The workflow is somehow equal like it was done in v1. 

I tried to add less overhead as possible. I know that you @jtreminio prefer working code before more elegant code which may introduce dozens of additional locs.

As showcase PuPHPet would  take now the hostname from the first available vhost from the apache or nginx configuration. With this addition I fixed the hostname configuration already existing in [the manifest template](https://github.com/puphpet/puphpet/blob/master/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.pp.twig#L4). It was not really used currently.

Refers to #252 and would fix #364 
