### PR TITLE
Set correct owner/group in Vagrant Local defaults.yml

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
@@ -7,6 +7,8 @@ vm:
             target: /var/www
             id: vagrant-root
             nfs: 'false'
+            owner: www-data
+            group: www-data
     network:
         forwarded_port:
             -


### PR DESCRIPTION
Set correct owner/group in Vagrant Local defaults.yml for synced_folder /var/www
Might be a problem because then the host's folder is writable by the webserver (which is kind of the point)...
Works for Debian, others might use other usernames like www or http.

Maybe make this a choice?

see also #321 #370 #274
