### PR TITLE
Update librarian script

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/librarian-puppet-vagrant.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/librarian-puppet-vagrant.sh
@@ -67,21 +67,15 @@ if [ "${OS}" == 'ubuntu' ]; then
     fi
 fi
 
-if [[ ! -f /.puphpet-stuff/librarian-puppet-installed ]]; then
-    echo 'Installing librarian-puppet'
-    gem install librarian-puppet-maestrodev >/dev/null
-    echo 'Finished installing librarian-puppet'
+echo 'Installing librarian-puppet'
+gem install librarian-puppet-maestrodev >/dev/null
+echo 'Finished installing librarian-puppet'
 
-    echo 'Running initial librarian-puppet'
-    cd "${PUPPET_DIR}" && librarian-puppet install --clean >/dev/null
-    echo 'Finished running initial librarian-puppet'
+echo 'Running initial librarian-puppet'
+cd "${PUPPET_DIR}" && librarian-puppet install --clean >/dev/null
+echo 'Finished running initial librarian-puppet'
 
-    touch /.puphpet-stuff/librarian-puppet-installed
-else
-    echo 'Running update librarian-puppet'
-    cd "${PUPPET_DIR}" && librarian-puppet update >/dev/null
-    echo 'Finished running update librarian-puppet'
-fi
+touch /.puphpet-stuff/librarian-puppet-installed
 
 echo "Replacing puppetlabs-git module with custom"
 rm -rf /etc/puppet/modules/git


### PR DESCRIPTION
**In short:** Latest librarian fixes are under `librarian-puppet-maestrodev` and not `librarian-puppet`

I tried to add https://github.com/willdurand/puppet-nodejs manually to puppet generate via website, but got error (solved here: https://github.com/rodjek/librarian-puppet/pull/94#issuecomment-30318287). Fix is not available via `gem install` (see: https://github.com/rodjek/librarian-puppet/issues/149#issuecomment-31340416).

I changed gem name and removed `if` clause, to ensure librarian is up to date to prevent similar cases.

I wonder if `touch /.puphpet-stuff/librarian-puppet-installed` should also be removed as it is only used in begining of same file to check some stuff (late night here, heh).
