### PR TITLE
Copy PMA folder instead of moving it

### DIFF
--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -97,7 +97,7 @@ if has_key($mysql_values, 'phpmyadmin') and $mysql_values['phpmyadmin'] == 1 and
   }
 
   exec { 'move phpmyadmin to webroot':
-    command => "mv /usr/share/${phpMyAdmin_folder} ${mysql_pma_webroot_location}/phpmyadmin",
+    command => "cp -R /usr/share/${phpMyAdmin_folder} ${mysql_pma_webroot_location}/phpmyadmin",
     onlyif  => "test ! -d ${mysql_pma_webroot_location}/phpmyadmin",
     require => [
       Package[$phpMyAdmin_package],


### PR DESCRIPTION
`mv` was returning `1` instead of a successful `0`, making `vagrant up` fail.

see https://github.com/puphpet/puphpet/issues/417
