### PR TITLE
Normalize configuration to single-quotes before sending it. fixes #448

### DIFF
--- a/web/assets/js/custom.js
+++ b/web/assets/js/custom.js
@@ -435,7 +435,7 @@ PUPHPET.uploadConfig = function() {
 
         var form = $(
             '<form action="' + uploadConfigUrl + '" method="post">' +
-                '<input type="hidden" name="config" value="' + config + '" />' +
+                '<input type="hidden" name="config" value="' + config.replace( /\"/g, "'" ) + '" />' +
             '</form>'
         );
         $('body').append(form);


### PR DESCRIPTION
Bug comes from generating the upload form. When we append double quotes the HTML markup breaks so all the fields after the double quotes get lost.

My approach is to normalize the quotes in the config file so, if an user adds double-quotes we convert them to single ones before sending the config to the server.
