### PR TITLE
DigitalOcean uses 12.04.3 now instead of 12.04

### DIFF
--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
@@ -28,8 +28,8 @@ available_images:
         php_versions:
             - 5.4
     -
-        image: Ubuntu 12.04 x64
-        long_name: Ubuntu Precise 12.04 x64
+        image: Ubuntu 12.04.3 x64
+        long_name: Ubuntu Precise 12.04.3 x64
         php_versions:
             - 5.4
             - 5.3


### PR DESCRIPTION
I'm not sure if this fixes the issue or not, but DigitalOcean doesn't have a Ubuntu 12.04 box. I was able to manually edit the config.yaml file in my ./puphpet directory and change the box string to 12.04.3, and it worked. I ran a find -exec grep "Ubuntu 12.04" on the src directory, and this is the only instance I found.
