### PR TITLE
Use group var from apache settings

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
+++ b/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
@@ -117,7 +117,7 @@ if count($php_values['ini']) > 0 {
 
     file { $php_values['ini']['session.save_path']:
       ensure  => directory,
-      group   => 'www-data',
+      group   => $apache_values['group'],
       mode    => 0775,
       require => Exec["mkdir -p ${php_values['ini']['session.save_path']}"]
     }


### PR DESCRIPTION
If I manually change `apache.group` in `puphpet/config.yml` to `vagrant`, then
PHP will not be able to write sessions to the folder. This change ensures that
the folder has the proper permissions.
