### PR TITLE
Update Ruby the right way.

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -29,7 +29,16 @@ if [[ ! -f /.puphpet-stuff/initial-setup-repo-update ]]; then
         echo "Updating to Ruby 1.9.3"
         yum install centos-release-SCL >/dev/null
         yum remove ruby >/dev/null
-        yum install ruby193 facter hiera ruby193-ruby-irb ruby193-ruby-doc ruby193-rubygem-json ruby193-libyaml >/dev/null
+
+        # As described here http://tecadmin.net/install-ruby-1-9-3-or-multiple-ruby-verson-on-centos-6-3-using-rvm/
+        yum install gcc-c++ patch readline readline-devel zlib zlib-devel >/dev/null
+        yum install libyaml-devel libffi-devel openssl-devel make >/dev/null
+        yum install bzip2 autoconf automake libtool bison iconv-devel >/dev/null
+        curl -L get.rvm.io | bash -s stable
+        source /etc/profile.d/rvm.sh
+        rvm install 1.9.3
+        rvm use 1.9.3 --default
+
         gem update --system >/dev/null
         gem install haml >/dev/null
         echo "Finished updating to Ruby 1.9.3"


### PR DESCRIPTION
There seems to be no such yum package as 'ruby193 ' and some of the others so that Ruby doesn't actually get updated here. Following the instructions here: http://tecadmin.net/install-ruby-1-9-3-or-multiple-ruby-verson-on-centos-6-3-using-rvm/ seems to solve it.
