### PR TITLE
use the yum priorities plugin

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -23,6 +23,7 @@ if [[ ! -f /.puphpet-stuff/initial-setup-repo-update ]]; then
     elif [[ "${OS}" == 'centos' ]]; then
         echo "Running initial-setup yum update"
         yum install yum-plugin-fastestmirror -y >/dev/null
+        yum install yum-plugin-priorities -y >/dev/null
         yum check-update -y >/dev/null
         echo "Finished running initial-setup yum update"
 


### PR DESCRIPTION
Use this: http://wiki.centos.org/PackageManagement/Yum/Priorities

Because, according to http://wiki.centos.org/PackageManagement/Yum/FastestMirror : "With both the protectbase and fastestmirror yum plugins installed, you should get the fastest updates with maximum protection from accidental damage from 3rd party repositories."
