### PR TITLE
Do not install ruby193 because it does not replace the installed ruby...

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -26,13 +26,10 @@ if [[ ! -f /.puphpet-stuff/initial-setup-repo-update ]]; then
         yum check-update -y >/dev/null
         echo "Finished running initial-setup yum update"
 
-        echo "Updating to Ruby 1.9.3"
-        yum install centos-release-SCL >/dev/null
-        yum remove ruby >/dev/null
-        yum install ruby193 facter hiera ruby193-ruby-irb ruby193-ruby-doc ruby193-rubygem-json ruby193-libyaml >/dev/null
+        yum -y install facter hiera >/dev/null
         gem update --system >/dev/null
+        gem install json >/dev/null
         gem install haml >/dev/null
-        echo "Finished updating to Ruby 1.9.3"
 
         echo "Installing basic development tools (CentOS)"
         yum -y groupinstall "Development Tools" >/dev/null


### PR DESCRIPTION
and it is not required for anything anyway.

Removing some lines because they don't work. In order to make them work, you'd need Yum's `-y` flag but don't do that! Because then you'll:
A) Get the SCL repo
B) Remove Ruby 1.8.7 (/usr/bin/ruby)
C) Install some other stuff including Ruby 1.9.3

Which all sounds peachy except that Ruby 1.9.3 does not replace the removed 1.8.7, so just running `ruby` from the command line will not work unless you first run a subshell. 

Which doesn't sound like too much trouble except that it still doesn't work because any script that starts out with `#!/usr/bin/ruby` will fail to find anything and will not work.

So anyway, why are we doing this? It doesn't accomplish anything and Puppet works just fine with Ruby 1.8.7. So just don't do this. 
