### PR TITLE
Escape backslashes in windows path

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/form/sections/SyncedFolder.html.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/form/sections/SyncedFolder.html.twig
@@ -19,7 +19,7 @@
                         <a href="http://docs.vagrantup.com/v2/synced-folders/index.html" target="_blank">more information</a>.
                         <strong>Windows users:</strong> You must use forward-slash
                         <code>c:/dev/vagrant/webroot</code> or double back-slash
-                        <code>c:\\dev\\vagrant\\webroot</code>')
+                        <code>c:\\\\dev\\\\vagrant\\\\webroot</code>')
                     }}
                 </label>
                 <input type="text" id="vagrantfile-local-vm-synced_folder-{{ uniqid }}-source"


### PR DESCRIPTION
double backslash is getting escaped so it only shows up as one on the site.
