### PR TITLE
Adding 'vagrant rsync' support for vagrant 1.5 to AWS, Digital Ocean and...

### DIFF
--- a/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/views/manifest/VagrantfileAws.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/views/manifest/VagrantfileAws.rb.twig
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
 
   data['vm']['synced_folder'].each do |i, folder|
     if folder['source'] != '' && folder['target'] != '' && folder['id'] != ''
-      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}"
+      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}", type: "rsync"
     end
   end
 

--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/manifest/VagrantfileDigitalOcean.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/manifest/VagrantfileDigitalOcean.rb.twig
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
 
   data['vm']['synced_folder'].each do |i, folder|
     if folder['source'] != '' && folder['target'] != '' && folder['id'] != ''
-      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}"
+      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}", type: "rsync"
     end
   end
 

--- a/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/views/manifest/VagrantfileRackspace.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/views/manifest/VagrantfileRackspace.rb.twig
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 
   data['vm']['synced_folder'].each do |i, folder|
     if folder['source'] != '' && folder['target'] != '' && folder['id'] != ''
-      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}"
+      config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{folder['id']}", type: "rsync"
     end
   end
 


### PR DESCRIPTION
... Rackspace

See blog post: https://www.vagrantup.com/blog/feature-preview-vagrant-1-5-rsync.html

Confirmed it works with aws, but may need testing with digital ocean and rackspace (assume they at least support rsync)
