### PR TITLE
Updating to Ruby 1.9.3 doesn't succeed

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -27,9 +27,9 @@ if [[ ! -f /.puphpet-stuff/initial-setup-repo-update ]]; then
         echo "Finished running initial-setup yum update"
 
         echo "Updating to Ruby 1.9.3"
-        yum install centos-release-SCL >/dev/null
-        yum remove ruby >/dev/null
-        yum install ruby193 facter hiera ruby193-ruby-irb ruby193-ruby-doc ruby193-rubygem-json ruby193-libyaml ruby-rgen >/dev/null
+        yum -y install centos-release-SCL >/dev/null
+        yum -y remove ruby >/dev/null
+        yum -y install ruby193 facter hiera ruby193-ruby-irb ruby193-ruby-doc ruby193-rubygem-json ruby193-libyaml ruby-rgen >/dev/null
         gem update --system >/dev/null
         gem install haml >/dev/null
         echo "Finished updating to Ruby 1.9.3"


### PR DESCRIPTION
I noticed this yesterday after the Puppet 3.5 release when my VMs started failing. Since the -y switch isn't passed to yum and the output is passed to /dev/null, the Ruby 1.9.3 installation doesn't occur. Another thing I noticed is that, if I changed the file as above, `gem` and `ruby` are both not found immediately after the install. It was kind of weird because, when going to the next step (previously "librarian-puppet.sh", now "r10k.sh"), that `gem` was now available.

Why this is happening, I can't really say, but I can confirm that Ruby 1.9.3 was not installed. I checked Ruby's version and it was still on 1.8.

FYI, I'm running a CentOS VM, so it might be something specific to CentOS.
