### PR TITLE
Iptables is blocking forwaded ports

### DIFF
--- a/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
+++ b/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
@@ -221,7 +221,9 @@ if $::osfamily == 'redhat' {
   if $vm_values == undef {
     $vm_values = hiera('vagrantfile-local', false)
   }
-  create_resources( iptables_port, $vm_values['vm']['network']['forwarded_port'] )
+  if $vm_values['vm']['network']['forwarded_port'] {
+    create_resources( iptables_port, $vm_values['vm']['network']['forwarded_port'] )
+  }
 }
 
 define iptables_port (


### PR DESCRIPTION
When setting forwarded ports on a RHEL/CentOS VM, Iptables is blocking any ports other than 80, 443 & 22. This will add ALLOW rules to Iptables to allow any forwarded ports to be accessible.
