### PR TITLE
Remove hardcoded Apache config loading from config.yaml

### DIFF
--- a/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
+++ b/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
@@ -1,9 +1,7 @@
 ## Begin Apache manifest
 
-if $yaml_values == undef {
-  $yaml_values = loadyaml('/vagrant/puphpet/config.yaml')
-} if $apache_values == undef {
-  $apache_values = $yaml_values['apache']
+if $apache_values == undef {
+  $apache_values = hiera('apache', false)
 } if $php_values == undef {
   $php_values = hiera('php', false)
 } if $hhvm_values == undef {


### PR DESCRIPTION
Is there a reason to hardcode apache value loading from config.yaml? This is quite a pain to find when customizing generated puphpet configs.
I tested it taking from hiera and it works perfectly.
