### PR TITLE
[DigitalOcean] Ubuntu 12.04.3 replaced by 12.04.4

### DIFF
--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
@@ -33,8 +33,8 @@ available_images:
             - 5.5
             - 5.4
     -
-        image: Ubuntu 12.04.3 x64
-        long_name: Ubuntu Precise 12.04.3 x64
+        image: Ubuntu 12.04.4 x64
+        long_name: Ubuntu Precise 12.04.4 x64
         php_versions:
             - 5.5
             - 5.4


### PR DESCRIPTION
Digital Ocean no longer sports a 12.04.3 version of Ubuntu.
