### PR TITLE
Run Puphpet configuration in Docker

### DIFF
--- a/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
+++ b/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
@@ -6,7 +6,7 @@ if $server_values == undef {
 
 # Check if $::ssh_username is not defined
 if $::ssh_username == undef {
-  $ssh_username = 'docker'
+  $ssh_username = 'root'
 }
 else{
   $ssh_username = $::ssh_username


### PR DESCRIPTION
#### Motivation:

Use the puphpet configuration in the Docker containers

---

Check if $::ssh_username is defined and create a new $ssh_username variable with the correct username
