### PR TITLE
Corrected Debian/Ubuntu Mysql client package name

### DIFF
--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -28,7 +28,7 @@ if hash_key_equals($mysql_values, 'install', 1) {
   } else {
     $mysql_server_require             = []
     $mysql_server_server_package_name = 'mysql-server'
-    $mysql_server_client_package_name = 'mysql'
+    $mysql_server_client_package_name = 'mysql-client'
   }
 
   if hash_key_equals($php_values, 'install', 1) {


### PR DESCRIPTION
Mysql was broken on Debian/Ubuntu by commit b3d76a068c330d2255d5f9b76eadeab3f5d9174a
