### PR TITLE
Fix for mysql client installation on non RHEL systems

### DIFF
--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -28,7 +28,7 @@ if hash_key_equals($mysql_values, 'install', 1) {
   } else {
     $mysql_server_require             = []
     $mysql_server_server_package_name = 'mysql-server'
-    $mysql_server_client_package_name = 'mysql'
+    $mysql_server_client_package_name = 'mysql-client'
   }
 
   if hash_key_equals($php_values, 'install', 1) {


### PR DESCRIPTION
On Debian based systems the mysql client package is called 'mysql-client'. I tested this change with Ubuntu 12.04 x64. Provision no longer fails.

---

```
Error: /Stage[main]/Mysql::Client::Install/Package[mysql_client]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install mysql' returned 100: Reading package lists...
```
