### PR TITLE
Sets non-interactive mode for debian installs

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/execute-files.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/execute-files.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 VAGRANT_CORE_FOLDER=$(cat "/.puphpet-stuff/vagrant-core-folder.txt")
 
 shopt -s nullglob

--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 VAGRANT_CORE_FOLDER=$(echo "$1")
 
 OS=$(/bin/bash "${VAGRANT_CORE_FOLDER}/shell/os-detect.sh" ID)

--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/os-detect.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
- 
+
 # Try and get debian operating system
 # id, codename, and release
 
@@ -40,9 +40,9 @@ info[id]=$(echo "${ID}" | tr '[A-Z]' '[a-z]')
 info[codename]=$(echo "${CODENAME}" | tr '[A-Z]' '[a-z]')
 info[release]=$(echo "${RELEASE}" | tr '[A-Z]' '[a-z]')
 
-if [ "$TYPE" ] ; then 
+if [ "$TYPE" ] ; then
     echo "${info[${TYPE}]}"
-else 
+else
     echo -e "ID\t${info[id]}"
     echo -e "CODENAME\t${info[codename]}"
     echo -e "RELEASE\t${info[release]}"

--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/r10k.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/r10k.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 VAGRANT_CORE_FOLDER=$(cat "/.puphpet-stuff/vagrant-core-folder.txt")
 
 OS=$(/bin/bash "${VAGRANT_CORE_FOLDER}/shell/os-detect.sh" ID)

--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/update-puppet.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/update-puppet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 VAGRANT_CORE_FOLDER=$(cat "/.puphpet-stuff/vagrant-core-folder.txt")
 
 OS=$(/bin/bash "${VAGRANT_CORE_FOLDER}/shell/os-detect.sh" ID)


### PR DESCRIPTION
This PR sets the value of DEBIAN_FRONTEND to `noninteractive` so that apt doesn't ask for user input when installing the packages.

I also snuck a whitespace fixing change in the commit.
