### PR TITLE
Restores the php 5.3 badge

### DIFF
--- a/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/config/available.yml
@@ -23,6 +23,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # US West (Northern California) Region
     us-west-1:
@@ -43,6 +44,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # US West (Northern California) Region
     us-west-2:
@@ -63,6 +65,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # EU (Ireland) Region
     eu-west-1:
@@ -83,6 +86,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # South America (Sao Paulo) Region
     sa-east-1:
@@ -103,6 +107,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # Asia Pacific (Tokyo) Region
     ap-northeast-1:
@@ -123,6 +128,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # Asia Pacific (Singapore) Region
     ap-southeast-1:
@@ -143,6 +149,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 # Asia Pacific (Sydney) Region
     ap-southeast-2:
@@ -163,6 +170,7 @@ available_images:
             php_versions:
                 - 5.5
                 - 5.4
+                - 5.3
                 - HHVM
 
 available_instance_types:

--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/config/available.yml
@@ -38,6 +38,7 @@ available_images:
         php_versions:
             - 5.5
             - 5.4
+            - 5.3
             - HHVM
 
 available_sizes:

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/available.yml
@@ -30,6 +30,7 @@ available_boxes:
         long_name: Debian Squeeze 6.0.7 x64 - Virtualbox 4.3
         php_versions:
             - 5.4
+            - 5.3
     -
         url: http://box.puphpet.com/ubuntu-precise12042-x64-vbox43.box
         os: ubuntu
@@ -38,6 +39,7 @@ available_boxes:
         php_versions:
             - 5.5
             - 5.4
+            - 5.3
             - HHVM
     -
         url: http://files.vagrantup.com/precise32.box
@@ -47,4 +49,5 @@ available_boxes:
         php_versions:
             - 5.5
             - 5.4
+            - 5.3
             - HHVM

--- a/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/config/available.yml
@@ -30,6 +30,7 @@ available_images:
         php_versions:
             - 5.5
             - 5.4
+            - 5.3
             - HHVM
 
 available_sizes:


### PR DESCRIPTION
A while back, the php 5.3 badge was removed from the VM selection page, even though php 5.3 is still being used, and is the default for Debian Squeeze and Ubuntu Precise. 

This PR simply restores the php 5.3 badge for distributions that ship and work well with 5.3 (namely precise and squeeze).
