### PR TITLE
Fixing issue #766: Adding mod_deflate and mod_expires to the list of options for apache configuration

### DIFF
--- a/src/Puphpet/Extension/ApacheBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/ApacheBundle/Resources/config/available.yml
@@ -21,7 +21,9 @@ available_modules:
     - cgid
     - dav
     - dav_fs
+    - deflate
     - disk_cache
+    - expires
     - headers
     - info
     - ldap


### PR DESCRIPTION
In issue #766 I reported I have a use case where I need to have mod_deflate and mod_expires as options for Apache configuration.

In this pull request I've added both options in the configuration settings for puphpet
