### PR TITLE
Fixes ownership in config.vm.synced_folder directive for Local deployment

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: nfs
       else
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: nfs,
-          group: 'www-data', user: 'www-data', mount_options: ["dmode=775", "fmode=764"]
+          group: 'www-data', owner: 'www-data', mount_options: ["dmode=775", "fmode=764"]
       end
     end
   end


### PR DESCRIPTION
fix for issue https://github.com/puphpet/puphpet/issues/794 

Not too much to discuss I wouldn't think.  All the pertinent info regarding the bug is in the issue referenced above.  This should do the trick.
