### PR TITLE
Set VM display name using hostname.

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -54,6 +54,7 @@ Vagrant.configure("2") do |config|
       end
 
       virtualbox.customize ["modifyvm", :id, "--memory", "#{data['vm']['memory']}"]
+      virtualbox.customize ["modifyvm", :id, "--name", config.vm.hostname]
     end
   end
 
@@ -70,6 +71,7 @@ Vagrant.configure("2") do |config|
       end
 
       v.vmx["memsize"] = "#{data['vm']['memory']}"
+      v.vmx["displayName"] = config.vm.hostname
     end
   end
 


### PR DESCRIPTION
Sets the virtual machine's "display" name so it is more easily recognizable when viewing your list of VMs in the VirtualBox Manager (or VMware Fusion Library). This is especially handy if you work on many client projects and have a dozen different nearly-identical VMs in the list.

![puphpet-set-vm-displayname](https://cloud.githubusercontent.com/assets/637270/3290306/c766f1d4-f576-11e3-8da8-502064e76acd.PNG)
