### PR TITLE
No set_php5_fpm_sock_group_and_user() for hhvm

### DIFF
--- a/src/Puphpet/Extension/NginxBundle/Resources/views/manifest/Nginx.pp.twig
+++ b/src/Puphpet/Extension/NginxBundle/Resources/views/manifest/Nginx.pp.twig
@@ -108,10 +108,6 @@ if hash_key_equals($nginx_values, 'install', 1) {
     }
   } elsif hash_key_equals($hhvm_values, 'install', 1) {
     $fastcgi_pass        = '127.0.0.1:9000'
-
-    set_php5_fpm_sock_group_and_user { 'hhvm':
-      require => Package['nginx'],
-    }
   } else {
     $fastcgi_pass        = ''
   }


### PR DESCRIPTION
Provisioning an hhvm & nginx box was failing for me. This fixes it for me.

This looks like php-only code and shouldn't be run for hhvm. When it is run, it causes commands to be run like

```
chmod 660  && chown www-data  && chgrp www-data
```

(these commands are missing the file argument)

Introduced here: https://github.com/puphpet/puphpet/commit/770aefd6e0d3654ef0bb35faa5c078c53ba2501c
