### PR TITLE
Xhprof - wrong library name in warning

### DIFF
--- a/src/Puphpet/Extension/XhprofBundle/Resources/views/form/Xhprof.html.twig
+++ b/src/Puphpet/Extension/XhprofBundle/Resources/views/form/Xhprof.html.twig
@@ -13,7 +13,7 @@
         <div class="row form-group">
             <div class="col-xs-12">
                 <p class="help-block">
-                    It is highly recommended <strong>not</strong> installing Beanstalk Console on production servers.
+                    It is highly recommended <strong>not</strong> installing Xhprof on production servers.
 
                     <br /><br />
 


### PR DESCRIPTION
Hi,

Just small pull request - There is incorrect library name in warning about xhprof on production servers.

JZ
