### PR TITLE
All PuPHPet files should keep LF

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/.gitattributes
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/.gitattributes
@@ -2,9 +2,4 @@
 * text=auto
 
 # Force the following filetypes to have unix eols, so Windows does not break them
-*.pp text eol=lf
-*.sh text eol=lf
-*.yaml text eol=lf
-Puppetfile text eol=lf
-.bash_aliases text eol=lf
-.vimrc text eol=lf
+*.* text eol=lf


### PR DESCRIPTION
**TL;DR:** CRLF causes problems in other file extensions too, not just the listed one.  Since PuPHPet is only ever executed on the guest (in theory), there is no reason that CRLF should be required in any of the files.

---

**Long Story**

My PuPHPet config was set to install BeanstalkD.  When I provisioned, I got the following error:

```
Error: Could not start Service[beanstalkd]: Execution of '/etc/init.d/beanstalkd start' returned 2:
Error: /Stage[main]/Main/Beanstalkd::Config[beanstalkd]/Service[beanstalkd]/ensure: change from stopped to running failed: Could not start Service[beanstalkd]: Execution of '/etc/init.d/beanstalkd start' returned 2:
```

When I tried to run `sudo /etc/init.d/beanstalkd start` in SSH, I got the following output:

```
: not found/beanstalkd: 4: /etc/default/beanstalkd:
: not found/beanstalkd: 5: /etc/default/beanstalkd:
: not found/beanstalkd: 7: /etc/default/beanstalkd:
: not found/beanstalkd: 8: /etc/default/beanstalkd:
: not found/beanstalkd: 9: /etc/default/beanstalkd:
: not found/beanstalkd: 13: /etc/default/beanstalkd:
: not found/beanstalkd: 16: /etc/default/beanstalkd:
: not found/beanstalkd: 18: /etc/default/beanstalkd:
: not found/beanstalkd: 19: /etc/default/beanstalkd:
: not found/beanstalkd: 23: /etc/default/beanstalkd:
: not found/beanstalkd: 25: /etc/default/beanstalkd:
: not found/beanstalkd: 26: /etc/default/beanstalkd:
: not found/beanstalkd: 31: /etc/default/beanstalkd:
: not found/beanstalkd: 34: /etc/default/beanstalkd:
: not found/beanstalkd: 35: /etc/default/beanstalkd:
: not found/beanstalkd: 38: /etc/default/beanstalkd:
: not found/beanstalkd: 40: /etc/default/beanstalkd:
: not found/beanstalkd: 41: /etc/default/beanstalkd:
: not found/beanstalkd: 42: /etc/default/beanstalkd:
: not found/beanstalkd: 43: /etc/default/beanstalkd:
: not found/beanstalkd: 44: /etc/default/beanstalkd:
: not found/beanstalkd: 46: /etc/default/beanstalkd:
/etc/init.d/beanstalkd: 47: /etc/default/beanstalkd: Syntax error: word unexpected (expecting "in")
```

This happened no matter how I ran the provisioning (`vagrant up` without an existing VM, `vagrant provision`, or `vagrant reload --provision`).

Looking at `file /etc/default/beanstalkd`, I see this:

```
/etc/default/beanstalkd: POSIX shell script, ASCII text executable, with CRLF line terminators
```

It appeared, therefore, that the BeanstalkD "defaults" file was being created with Windows line endings, which aren't compatible with Bash.

However, the original [Template file](https://rawgit.com/puphpet/puppet-beanstalkd/master/templates/debian/beanstalkd_default.erb) is correct - i.e. the `CRLF` is not saved in the Git repository.

I found, however, that the local copy of `beanstalkd_default.erb` was, in fact, converted to `CRLF` when I checked out the repository from my Git server.  This is because the `.gitattributes` file in `/puphpet/` does not include `erb` in the list of file types that must have `LF` line endings.
