### PR TITLE
Use DigitalOcean token instead of api user/key

### DIFF
--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/manifest/VagrantfileDigitalOcean.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/manifest/VagrantfileDigitalOcean.rb.twig
@@ -17,8 +17,7 @@ Vagrant.configure("2") do |config|
   config.ssh.username = "#{data['ssh']['username']}"
 
   config.vm.provider :digital_ocean do |provider|
-    provider.client_id = "#{data['vm']['provider']['digital_ocean']['client_id']}"
-    provider.api_key = "#{data['vm']['provider']['digital_ocean']['api_key']}"
+    provider.token = "#{data['vm']['provider']['digital_ocean']['token']}"
     provider.image = "#{data['vm']['provider']['digital_ocean']['image']}"
     provider.region = "#{data['vm']['provider']['digital_ocean']['region']}"
     provider.size = "#{data['vm']['provider']['digital_ocean']['size']}"


### PR DESCRIPTION
Related to #886 - I tried to run `vagrant up` on my machine using a DigitalOcean configuration, and it kept giving me the error:

```
Digital Ocean Provider:
* Token is required
```

Since I already updated the `config.yml` with my token, I was very confused. Changing these lines in the Vagrantfile to use the token instead of the client_id and api_key resolves this issue.
