### PR TITLE
Grab Apache values from hiera rather than directly from config.yaml

### DIFF
--- a/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
+++ b/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
@@ -1,5 +1,4 @@
-if $yaml_values == undef { $yaml_values = loadyaml('/vagrant/puphpet/config.yaml') }
-if $apache_values == undef { $apache_values = $yaml_values['apache'] }
+if $apache_values == undef { $apache_values = hiera('apache', false) }
 if $php_values == undef { $php_values = hiera('php', false) }
 if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
 


### PR DESCRIPTION
Loading the Apache configuration straight from config.yaml makes it impossible to override default values in config.yaml using the hiera hierarchy (example: different Apache settings for local / staging / production environments).

It's also the only instance of config.yaml being referenced explicitly within `puppet/nodes/*.pp` rather than using hiera, so I thought it might have been an oversight.
