### PR TITLE
Use hiera_hash(...) instead of hiera(...) so that matches throughout the Hiera hierarchy can be merged

### DIFF
--- a/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
+++ b/src/Puphpet/Extension/ApacheBundle/Resources/views/manifest/Apache.pp.twig
@@ -1,7 +1,7 @@
 if $yaml_values == undef { $yaml_values = loadyaml('/vagrant/puphpet/config.yaml') }
 if $apache_values == undef { $apache_values = $yaml_values['apache'] }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/BeanstalkdBundle/Resources/views/manifest/Beanstalkd.pp.twig
+++ b/src/Puphpet/Extension/BeanstalkdBundle/Resources/views/manifest/Beanstalkd.pp.twig
@@ -1,8 +1,8 @@
-if $beanstalkd_values == undef { $beanstalkd_values = hiera('beanstalkd', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $beanstalkd_values == undef { $beanstalkd_values = hiera_hash('beanstalkd', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/DrushBundle/Resources/views/manifest/Drush.pp.twig
+++ b/src/Puphpet/Extension/DrushBundle/Resources/views/manifest/Drush.pp.twig
@@ -1,6 +1,6 @@
-if $drush_values == undef { $drush_values = hiera('drush', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
+if $drush_values == undef { $drush_values = hiera_hash('drush', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/ElasticSearchBundle/Resources/views/manifest/ElasticSearch.pp.twig
+++ b/src/Puphpet/Extension/ElasticSearchBundle/Resources/views/manifest/ElasticSearch.pp.twig
@@ -1,4 +1,4 @@
-if $elasticsearch_values == undef { $elasticsearch_values = hiera('elastic_search', false) }
+if $elasticsearch_values == undef { $elasticsearch_values = hiera_hash('elastic_search', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/FirewallBundle/Resources/views/manifest/Firewall.pp.twig
+++ b/src/Puphpet/Extension/FirewallBundle/Resources/views/manifest/Firewall.pp.twig
@@ -1,5 +1,5 @@
-if $firewall_values == undef { $firewall_values = hiera('firewall', false) }
-if $vm_values == undef { $vm_values = hiera($::vm_target_key, false) }
+if $firewall_values == undef { $firewall_values = hiera_hash('firewall', false) }
+if $vm_values == undef { $vm_values = hiera_hash($::vm_target_key, false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/HhvmBundle/Resources/views/manifest/Hhvm.pp.twig
+++ b/src/Puphpet/Extension/HhvmBundle/Resources/views/manifest/Hhvm.pp.twig
@@ -1,6 +1,6 @@
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
 
 include puphpet::params
 include puphpet::supervisord

--- a/src/Puphpet/Extension/MailCatcherBundle/Resources/views/manifest/MailCatcher.pp.twig
+++ b/src/Puphpet/Extension/MailCatcherBundle/Resources/views/manifest/MailCatcher.pp.twig
@@ -1,4 +1,4 @@
-if $mailcatcher_values == undef { $mailcatcher_values = hiera('mailcatcher', false) }
+if $mailcatcher_values == undef { $mailcatcher_values = hiera_hash('mailcatcher', false) }
 
 include puphpet::params
 include puphpet::supervisord

--- a/src/Puphpet/Extension/MariaDbBundle/Resources/views/manifest/MariaDb.pp.twig
+++ b/src/Puphpet/Extension/MariaDbBundle/Resources/views/manifest/MariaDb.pp.twig
@@ -1,8 +1,8 @@
-if $mariadb_values == undef { $mariadb_values = hiera('mariadb', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $mariadb_values == undef { $mariadb_values = hiera_hash('mariadb', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/MongoDbBundle/Resources/views/manifest/MongoDb.pp.twig
+++ b/src/Puphpet/Extension/MongoDbBundle/Resources/views/manifest/MongoDb.pp.twig
@@ -1,7 +1,7 @@
-if $mongodb_values == undef { $mongodb_values = hiera('mongodb', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $mongodb_values == undef { $mongodb_values = hiera_hash('mongodb', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -1,7 +1,7 @@
-if $mysql_values == undef { $mysql_values = hiera('mysql', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $mysql_values == undef { $mysql_values = hiera_hash('mysql', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/NginxBundle/Resources/views/manifest/Nginx.pp.twig
+++ b/src/Puphpet/Extension/NginxBundle/Resources/views/manifest/Nginx.pp.twig
@@ -1,6 +1,6 @@
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $hhvm_values == undef { $hhvm_values = hiera_hash('hhvm', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/NodeJsBundle/Resources/views/manifest/NodeJs.pp.twig
+++ b/src/Puphpet/Extension/NodeJsBundle/Resources/views/manifest/NodeJs.pp.twig
@@ -1,4 +1,4 @@
-if $nodejs_values == undef { $nodejs_values = hiera('nodejs', false) }
+if $nodejs_values == undef { $nodejs_values = hiera_hash('nodejs', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
+++ b/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
@@ -1,7 +1,7 @@
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
-if $mailcatcher_values == undef { $mailcatcher_values = hiera('mailcatcher', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $apache_values == undef { $apache_values = hiera_hash('apache', false) }
+if $nginx_values == undef { $nginx_values = hiera_hash('nginx', false) }
+if $mailcatcher_values == undef { $mailcatcher_values = hiera_hash('mailcatcher', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/PostgresqlBundle/Resources/views/manifest/Postgresql.pp.twig
+++ b/src/Puphpet/Extension/PostgresqlBundle/Resources/views/manifest/Postgresql.pp.twig
@@ -1,6 +1,6 @@
-if $postgresql_values == undef { $postgresql_values = hiera('postgresql', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $hhvm_values == undef { $hhvm_values = hiera('hhvm', false) }
+if $postgresql_values == undef { $postgresql_values = hiera_hash('postgresql', false) }
+if $php_values == undef { $php_valuhiera_hash(iera('php', false) }
+if $hhvm_values == undef { $hhvmhiera_hash(s = hiera('hhvm', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/RabbitMQBundle/Resources/views/manifest/RabbitMQ.pp.twig
+++ b/src/Puphpet/Extension/RabbitMQBundle/Resources/views/manifest/RabbitMQ.pp.twig
@@ -1,7 +1,7 @@
-if $rabbitmq_values == undef { $rabbitmq_values = hiera('rabbitmq', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $rabbitmq_values == undef { $rabbitmq_values = hiera_hash('rabbitmq', false) }
+if $php_values == undef { $php_valuhiera_hash(iera('php', false) }
+if $apache_values == undef { $apachehiera_hash(s = hiera('apache', false) }
+if $nginx_values == undef { $hiera_hash(values = hiera('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/RedisBundle/Resources/views/manifest/Redis.pp.twig
+++ b/src/Puphpet/Extension/RedisBundle/Resources/views/manifest/Redis.pp.twig
@@ -1,7 +1,7 @@
-if $redis_values == undef { $redis_values = hiera('redis', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $redis_values == undef { $redis_values = hiera_hash('redis', false) }
+if $php_values == undef { $php_valuhiera_hash(iera('php', false) }
+if $apache_values == undef { $apachehiera_hash(s = hiera('apache', false) }
+if $nginx_values == undef { $hiera_hash(values = hiera('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/RubyBundle/Resources/views/manifest/Ruby.pp.twig
+++ b/src/Puphpet/Extension/RubyBundle/Resources/views/manifest/Ruby.pp.twig
@@ -1,4 +1,4 @@
-if $ruby_values == undef { $ruby_values = hiera('ruby', false) }
+if $ruby_values == undef { $ruby_values = hiera_hash('ruby', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
+++ b/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
@@ -1,4 +1,4 @@
-if $server_values == undef { $server_values = hiera('server', false) }
+if $server_values == undef { $server_values = hiera_hash('server', false) }
 
 include ntp
 include swap_file

--- a/src/Puphpet/Extension/SqliteBundle/Resources/views/manifest/Sqlite.pp.twig
+++ b/src/Puphpet/Extension/SqliteBundle/Resources/views/manifest/Sqlite.pp.twig
@@ -1,8 +1,8 @@
-if $sqlite_values == undef { $sqlite_values = hiera('sqlite', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
-if $mailcatcher_values == undef { $mailcatcher_values = hiera('mailcatcher', false) }
+if $sqlite_values == undef { $sqlite_values = hiera_hash('sqlite', false) }
+if $php_values == undef { $php_valuhiera_hash(iera('php', false) }
+if $apache_values == undef { $apachehiera_hash(s = hiera('apache', false) }
+if $nginx_values == undef { $hiera_hash(values = hiera('nginx', false) }
+if $mailcatcher_values == undef { $mhiera_hash(cher_values = hiera('mailcatcher', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/XdebugBundle/Resources/views/manifest/Xdebug.pp.twig
+++ b/src/Puphpet/Extension/XdebugBundle/Resources/views/manifest/Xdebug.pp.twig
@@ -1,7 +1,7 @@
-if $xdebug_values == undef { $xdebug_values = hiera('xdebug', false) }
-if $php_values == undef { $php_values = hiera('php', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $xdebug_values == undef { $xdebug_values = hiera_hash('xdebug', false) }
+if $php_values == undef { $php_valuhiera_hash(iera('php', false) }
+if $apache_values == undef { $apachehiera_hash(s = hiera('apache', false) }
+if $nginx_values == undef { $hiera_hash(values = hiera('nginx', false) }
 
 include puphpet::params
 

--- a/src/Puphpet/Extension/XhprofBundle/Resources/views/manifest/Xhprof.pp.twig
+++ b/src/Puphpet/Extension/XhprofBundle/Resources/views/manifest/Xhprof.pp.twig
@@ -1,7 +1,7 @@
-if $php_values == undef { $php_values = hiera('php', false) }
-if $xhprof_values == undef { $xhprof_values = hiera('xhprof', false) }
-if $apache_values == undef { $apache_values = hiera('apache', false) }
-if $nginx_values == undef { $nginx_values = hiera('nginx', false) }
+if $php_values == undef { $php_values = hiera_hash('php', false) }
+if $xhprof_values == undef { $xhprof_valuhiera_hash(iera('xhprof', false) }
+if $apache_values == undef { $apachehiera_hash(s = hiera('apache', false) }
+if $nginx_values == undef { $hiera_hash(values = hiera('nginx', false) }
 
 include puphpet::params
 


### PR DESCRIPTION
Using `hiera(...)` to retrieve config settings prevents [hierarchies](https://docs.puppetlabs.com/hiera/1/hierarchy.html) from being merged correctly. `hiera_hash(...)` is required for the merges to take place properly (see [Hiera Hash](https://docs.puppetlabs.com/references/latest/function.html#hierahash) and [Hiera Lookup Functions](https://docs.puppetlabs.com/hiera/1/puppet.html#hiera-lookup-functions))

This PR changes all instances of `hiera(...)` to `hiera_hash(...)`.

**Note:** `hiera_hash(...)` expects the top-level value in the hierarchy to be a hash, but this should be backwards compatible because all affected configurations are hashes.
