### PR TITLE
Best position for config.vm.post_up_message is right after network

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/data.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/data.yml
@@ -8,6 +8,7 @@ vm:
     network:
         private_network: 192.168.56.101
         forwarded_port: []
+    post_up_message: ''
     provider:
         virtualbox:
             modifyvm:
@@ -29,7 +30,6 @@ vm:
     usable_port_range:
         start: 10200
         stop: 10500
-    post_up_message: ''
 
 ssh:
     host: ~

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
@@ -23,6 +23,7 @@ vm:
             -
                 guest: ~
                 host: ~
+    post_up_message: ''
     provision:
         puppet:
             manifests_path: "puphpet/puppet"
@@ -35,6 +36,5 @@ vm:
     usable_port_range:
         start: 10200
         stop: 10500
-    post_up_message: ''
 ssh:
     forward_agent: true

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -25,6 +25,10 @@ Vagrant.configure('2') do |config|
     end
   end
 
+  if !data['vm']['post_up_message'].nil?
+    config.vm.post_up_message = "#{data['vm']['post_up_message']}"
+  end
+
   if Vagrant.has_plugin?('vagrant-hostmanager')
     hosts = Array.new()
 
@@ -244,9 +248,4 @@ Vagrant.configure('2') do |config|
   if !data['vagrant']['host'].nil?
     config.vagrant.host = data['vagrant']['host'].gsub(':', '').intern
   end
-
-  if !data['vm']['post_up_message'].nil?
-    config.vm.post_up_message = "#{data['vm']['post_up_message']}"
-  end
-
 end


### PR DESCRIPTION
`config.vm.post_up_message` setting is one of the category of `config.vm` and placing it right after the `config.host` is not right in my opinion or sense. But really thanks for this setting adaptation.
