### PR TITLE
Change MySQL Resource Key from user@name to Config Key

### DIFF
--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/form/Mysql.html.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/form/Mysql.html.twig
@@ -68,7 +68,7 @@
 
                         <br /><br />
 
-                        If you want to assign a user to multiple databases, simply create more databases and type in
+                        If you want to assign a user to multiple hosts or databases, simply create more databases and type in
                         the same username and password. Only the password for the first entry will be considered,
                         <strong>but all fields must be completed</strong>!
                     </p>

--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -61,7 +61,7 @@ if hash_key_equals($mysql_values, 'install', 1) {
         }), 'name')
 
         create_resources( puphpet::mysql::db, {
-          "${database['user']}@${database['name']}" => $database_merged
+          "${key}" => $database_merged
         })
       }
     }


### PR DESCRIPTION
Change MySQL Resource Key from user@name to Config Key to increase the possibility of user, hosts and database combinations, this way one can attach the same user on a different host to the same database, which was not possible before due to conflicts on the ky.

Change text on form to represent this change
