### PR TITLE
Check if modifyvm.name is set before use the hostname as vm name.

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -149,8 +149,11 @@ Vagrant.configure('2') do |config|
       v.vmx['memsize']  = "#{data['vm']['memory']}"
       v.vmx['numvcpus'] = "#{data['vm']['cpus']}"
 
-      if data['vm']['hostname'].to_s.strip.length != 0
-        v.vmx['displayName'] = config.vm.hostname
+      if data['vm']['provider']['vmware']['displayName'].nil? ||
+        data['vm']['provider']['vmware']['displayName'].empty?
+        if data['vm']['hostname'].to_s.strip.length != 0
+          v.vmx['displayName'] = config.vm.hostname
+        end
       end
     end
   end
@@ -173,8 +176,11 @@ Vagrant.configure('2') do |config|
       v.memory = "#{data['vm']['memory']}"
       v.cpus   = "#{data['vm']['cpus']}"
 
-      if data['vm']['hostname'].to_s.strip.length != 0
-        v.name = config.vm.hostname
+      if data['vm']['provider']['parallels']['name'].nil? ||
+        data['vm']['provider']['parallels']['name'].empty?
+        if data['vm']['hostname'].to_s.strip.length != 0
+          v.name = config.vm.hostname
+        end
       end
     end
   end


### PR DESCRIPTION
Check if modifyvm.name is set before use the hostname as vm name.
This way one can use different values for hostname and vm name
Previously even if the modify.vm value was set the hostname was subscribing this value
