### PR TITLE
Install gettext and subversion

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/initial-setup.sh
@@ -32,6 +32,14 @@ if [ "${OS}" == 'debian' ] || [ "${OS}" == 'ubuntu' ]; then
     apt-get -y install git-core >/dev/null
     echo 'Finished installing git'
 
+    echo 'Installing gettext'
+    apt-get -y install gettext >/dev/null
+    echo 'Finished installing gettext'
+    
+    echo 'Installing subversion'
+    apt-get -y install subversion >/dev/null
+    echo 'Finished installing subversion'
+
     if [[ "${CODENAME}" == 'lucid' || "${CODENAME}" == 'precise' ]]; then
         echo 'Installing basic curl packages'
         apt-get -y install libcurl3 libcurl4-gnutls-dev curl >/dev/null


### PR DESCRIPTION
On Ubuntu and Debian `gettext` library and `subversion` VCS are not installed by `build-essential` packages but on CentOS they are installed with `Development Tools`.
Since, `gettext` packages is mostly used for localization or internationalization and subversion is one of the VCS. Believe me this both server packages are used by mostly WordPress developers frequently so package those in PuPHPet box through this shell changes in `initial-setup.sh`.
