### PR TITLE
New era for usable_port_range

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/data.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/data.yml
@@ -28,8 +28,8 @@ vm:
                 - "--parser future"
     synced_folder: []
     usable_port_range:
-        start: 10200
-        stop: 10500
+        start: '10200'
+        stop: '10500'
 
 ssh:
     host: ~

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
@@ -35,7 +35,7 @@ vm:
                 - "--hiera_config /vagrant/puphpet/puppet/hiera.yaml"
                 - "--parser future"
     usable_port_range:
-        start: 10200
-        stop: 10500
+        start: '10200'
+        stop: '10500'
 ssh:
     forward_agent: true

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -98,7 +98,7 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  config.vm.usable_port_range = (data['vm']['usable_port_range']['start'].to_i..data['vm']['usable_port_range']['stop'].to_i)
+  config.vm.usable_port_range = Range.new(data['vm']['usable_port_range']['start'].to_i, data['vm']['usable_port_range']['stop'].to_i)
 
   if data['vm']['chosen_provider'].empty? || data['vm']['chosen_provider'] == 'virtualbox'
     ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'


### PR DESCRIPTION
Utilize the ruby function `Range.new(start, end)` rather than using `(start..end)` for `config.vm.usable_port_range`
