### PR TITLE
Fix for php session path not being writable in the cli

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
+++ b/src/Puphpet/Extension/PhpBundle/Resources/views/manifest/Php.pp.twig
@@ -141,7 +141,7 @@ if hash_key_equals($php_values, 'install', 1) {
         ensure => directory,
         group  => 'www-data',
         owner  => 'www-data',
-        mode   => 0755,
+        mode   => 0775,
       }
     }
   }


### PR DESCRIPTION
Noticed a bunch of session-related permission errors after updating an old PuPHPet VM and realized it was due to changes in how the session save path directory was handled.

The `Php.pp.twig` file used to create them with mode `0775` but that changed in 8e30179a5b8878a2440d69d91b22a797bc1f06f5, and now scripts being run as the `vagrant` user in the CLI (such as unit tests) can't write to the session dir.
