### PR TITLE
Ability to choose a user/group for synced_folders

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/config/defaults.yml
@@ -11,6 +11,8 @@ vm:
             target: /var/www
             id: vagrant-root
             sync_type: 'default'
+            owner: 'www-data'
+            group: 'www-data'
             rsync:
                 args:
                     - "--verbose"

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/form/sections/SyncedFolder.html.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/form/sections/SyncedFolder.html.twig
@@ -40,6 +40,34 @@
         </div>
 
         <div class="row form-group">
+            <div class="col-md-6">
+                <label for="vagrantfile-local-vm-synced_folder-{{ uniqid }}-owner">
+                    Sync Owner
+                    {{ popover.small('The user who should be the owner of this synced folder. Some synced folder types don\'t support modifying the owner,
+                        <a href="http://docs.vagrantup.com/v2/synced-folders/index.html" target="_blank">more information</a>')
+                    }}
+                </label>
+                <input type="text" id="vagrantfile-local-vm-synced_folder-{{ uniqid }}-owner"
+                       name="vagrantfile-local[vm][synced_folder][{{ uniqid }}][owner]"
+                       required placeholder="www-data"
+                       value="{{ synced_folder.owner }}" class="form-control" />
+            </div>
+
+            <div class="col-md-6">
+                <label for="vagrantfile-local-vm-synced_folder-{{ uniqid }}-group">
+                    Sync Group
+                    {{ popover.small('The group that will own the synced folder. Some synced folder types don\'t support modifying the group,
+                        <a href="http://docs.vagrantup.com/v2/synced-folders/index.html" target="_blank">more information</a>')
+                    }}
+                </label>
+                <input type="text" id="vagrantfile-local-vm-synced_folder-{{ uniqid }}-group"
+                       name="vagrantfile-local[vm][synced_folder][{{ uniqid }}][group]"
+                       required placeholder="www-data"
+                       value="{{ synced_folder.group }}" class="form-control" />
+            </div>
+        </div>
+
+        <div class="row form-group">
             <div class="col-md-12">
                 <label>
                     Shared Folder Type

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -80,6 +80,8 @@ Vagrant.configure('2') do |config|
 
   data['vm']['synced_folder'].each do |i, folder|
     if folder['source'] != '' && folder['target'] != ''
+      sync_owner = !folder['sync_owner'].nil? ? folder['sync_owner'] : 'www-data'
+      sync_group = !folder['sync_group'].nil? ? folder['sync_group'] : 'www-data'
       if folder['sync_type'] == 'nfs'
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
       elsif folder['sync_type'] == 'smb'
@@ -90,10 +92,10 @@ Vagrant.configure('2') do |config|
         rsync_exclude = !folder['rsync']['exclude'].nil? ? folder['rsync']['exclude'] : ['.vagrant/']
 
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
-          rsync__args: rsync_args, rsync__exclude: rsync_exclude, rsync__auto: rsync_auto, type: 'rsync'
+          rsync__args: rsync_args, rsync__exclude: rsync_exclude, rsync__auto: rsync_auto, type: 'rsync', group: sync_group, owner: sync_owner
       else
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
-          group: 'www-data', owner: 'www-data', mount_options: ['dmode=775', 'fmode=764']
+          group: sync_group, owner: sync_owner, mount_options: ['dmode=775', 'fmode=764']
       end
     end
   end


### PR DESCRIPTION
Currently synced rsync-directories is setting synced files to `vagrant:vagrant` which could lead to errors for specific applications while generating files/folders.. 

This will set the default to `www-data:www-data` including the ability to change it within the configuration.
