### PR TITLE
Parallels provider: Fixed mount options for synced folders

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -91,6 +91,9 @@ Vagrant.configure('2') do |config|
 
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
           rsync__args: rsync_args, rsync__exclude: rsync_exclude, rsync__auto: rsync_auto, type: 'rsync'
+      elsif data['vm']['chosen_provider'] == 'parallels'
+        config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
+          group: 'www-data', owner: 'www-data', mount_options: ['share']
       else
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
           group: 'www-data', owner: 'www-data', mount_options: ['dmode=775', 'fmode=764']


### PR DESCRIPTION
Mount options "dmode" and "fmode" are unavailable for "prl_fs"
filesystem. Use mount option "share", which provides liberal access
permissions to shared folders.

Related issus:
https://github.com/Parallels/vagrant-parallels/issues/135
https://github.com/Parallels/vagrant-parallels/issues/140
