### PR TITLE
This fixes a regression bug re: creating ssh-user directory

### DIFF
--- a/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
+++ b/src/Puphpet/Extension/ServerBundle/Resources/views/manifest/Server.pp.twig
@@ -25,6 +25,11 @@ user { ['apache', 'nginx', 'httpd', 'www-data']:
   require => Group['www-data']
 }
 
+file { "/home/${::ssh_username}":
+  ensure => directory,
+  owner  => $::ssh_username,
+}
+
 # copy dot files to ssh user's home directory
 exec { 'dotfiles':
   cwd     => "/home/${::ssh_username}",


### PR DESCRIPTION
This used to be present before the manifest was broken up into multiple files.
