### PR TITLE
Allow specification of owner and group for synced folders with type "rsy...

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/manifest/VagrantfileLocal.rb.twig
@@ -90,7 +90,7 @@ Vagrant.configure('2') do |config|
         rsync_exclude = !folder['rsync']['exclude'].nil? ? folder['rsync']['exclude'] : ['.vagrant/']
 
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
-          rsync__args: rsync_args, rsync__exclude: rsync_exclude, rsync__auto: rsync_auto, type: 'rsync'
+          rsync__args: rsync_args, rsync__exclude: rsync_exclude, rsync__auto: rsync_auto, type: 'rsync', owner: "#{folder['rsync']['owner']}", group: "#{folder['rsync']['group']}"
       else
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}",
           group: 'www-data', owner: 'www-data', mount_options: ['dmode=775', 'fmode=764']


### PR DESCRIPTION
...nc"

Example how to set it up in config.yaml:

```
            rsync:
                args:
                    - '--verbose'
                    - '--archive'
                    - '-z'
                exclude:
                    - .git/
                auto: 'true'
                owner: 'www-data'
                group: 'www-data'
```
