### PR TITLE
expand default roles to allow full access to the database

### DIFF
--- a/src/Puphpet/Extension/MongoDbBundle/Resources/views/manifest/MongoDb.pp.twig
+++ b/src/Puphpet/Extension/MongoDbBundle/Resources/views/manifest/MongoDb.pp.twig
@@ -61,7 +61,7 @@ define mongodb_db (
   $dbname,
   $user,
   $password,
-  $roles     = ['dbAdmin'],
+  $roles     = ['dbAdmin', 'readWrite', 'userAdmin'],
   $tries     = 10,
 ) {
   if ! value_true($name) or ! value_true($password) {


### PR DESCRIPTION
following change gave me full access to the dababase (that is i could access it entirely via GUI client) - mongo has very "strange" access controll philosophy :/ it would be nice to extract this option into config.yaml :)
