### PR TITLE
add override_options support from puppetlabs-mysql to mysql config

### DIFF
--- a/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
+++ b/src/Puphpet/Extension/MysqlBundle/Resources/views/manifest/Mysql.pp.twig
@@ -43,10 +43,13 @@ if hash_key_equals($mysql_values, 'install', 1) {
   }
 
   if $mysql_values['root_password'] {
+    $mysql_override_options = $mysql_values['override_options']
+
     class { 'mysql::server':
-      package_name  => $mysql_server_server_package_name,
-      root_password => $mysql_values['root_password'],
-      require       => $mysql_server_require
+      package_name     => $mysql_server_server_package_name,
+      root_password    => $mysql_values['root_password'],
+      require          => $mysql_server_require,
+      override_options => $mysql_override_options
     }
 
     class { 'mysql::client':


### PR DESCRIPTION
Related to: #692, #1035, this adds the ability to override mysql config via puppetlabs-mysql `override_options` parameter. This allows passing the override_options in the config.yml like so:

```
mysql:
    install: '1'
    root_password: 'abc123'
    adminer: '1'
    databases:
        3NzVHNgne2pm:
            grant:
                - ALL
            name: dev
            host: localhost
            user: user1
            password: 'abc123'
            sql_file: ''
    override_options:
        mysqld:
            max_allowed_packet: '32M'
```

Exposing this in the UI would require some work to support the sections in the my.cnf, but it's definitely possible. If there is precedent for this type of structured config elsewhere in the application, I'll gladly add it to the UI.
