### PR TITLE
Issue #1057: Add a better explanation about choosing mod_php

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/views/form/Php.html.twig
+++ b/src/Puphpet/Extension/PhpBundle/Resources/views/form/Php.html.twig
@@ -203,7 +203,9 @@
                             by default. If you want to use mod_php, check the box above. This only affects your VM
                             if you have chosen to use Apache. Nginx uses PHP-FPM.
                             <br /><br />
-                            It is recommended you <strong>not</strong> use mod_php and keep the box unchecked!
+                            If you check this box, then PuPHPet will use <strong>Apache 2.2</strong> It is
+                            recommended you <strong>not</strong> use mod_php and keep the box unchecked so
+                            that you can use the latest, better-performing <strong>Apache 2.4</strong>.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
This would help clarify to users why their PuPHPet configuration is not working on Debian Wheezy 32-bit and 64-bit due to issues with Apache 2.4.

See #1057.
