### PR TITLE
Add keys, required by RVM 1.2.6+

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh
+++ b/src/Puphpet/MainBundle/Resources/views/manifest/puphpet/shell/install-ruby.sh
@@ -50,6 +50,9 @@ fi
 
 echo 'Installing Ruby 1.9.3 using RVM'
 
+#RVM version 1.2.6+ requires keys
+gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+
 curl -sSL https://get.rvm.io | bash -s stable --quiet-curl --ruby=1.9.3
 source /usr/local/rvm/scripts/rvm
 


### PR DESCRIPTION
Added keys before RVM installation, as required by RVM 1.2.6+
Referenced: https://github.com/puphpet/puphpet/issues/1181#issuecomment-61346307
