### PR TITLE
Fix args to execute-files.sh provisioner

### DIFF
--- a/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileAwsBundle/Resources/views/Vagrantfile.rb.twig
@@ -66,11 +66,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 

--- a/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileDigitalOceanBundle/Resources/views/Vagrantfile.rb.twig
@@ -55,11 +55,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 

--- a/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/views/Vagrantfile.rb.twig
@@ -55,11 +55,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 

--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
@@ -218,11 +218,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 

--- a/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileRackspaceBundle/Resources/views/Vagrantfile.rb.twig
@@ -61,11 +61,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 

--- a/src/Puphpet/Extension/VagrantfileSoftlayerBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileSoftlayerBundle/Resources/views/Vagrantfile.rb.twig
@@ -57,11 +57,11 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['exec-once', 'exec-always']
+    s.args = ['exec-once', 'startup-once']
   end
   config.vm.provision :shell, run: 'always' do |s|
     s.path = 'puphpet/shell/execute-files.sh'
-    s.args = ['startup-once', 'startup-always']
+    s.args = ['exec-always', 'startup-always']
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 


### PR DESCRIPTION
so that 'exec-once' and 'startup-once' are run once and 'exec-always' and 'startup-always' are run always.
