### PR TITLE
Update Linode's available Debian Wheezy version

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/config/available.yml
@@ -14,8 +14,8 @@ available_distributions:
             - 5.4
             - HHVM
     -
-        distribution: Debian 7.6
-        long_name: Debian Wheezy 7.6 x64
+        distribution: Debian 7.7
+        long_name: Debian Wheezy 7.7 x64
         php_versions:
             - 5.6
             - 5.5

--- a/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/VagrantfileLinodeBundle/Resources/config/defaults.yml
@@ -1,7 +1,7 @@
 vm:
     provider:
         linode:
-            distribution: Debian 7.6
+            distribution: Debian 7.7
             datacenter: Newark
             plan: 1024
             token: LINODE_API_KEY


### PR DESCRIPTION
Linode updated their supported version on 12/24 from 7.6 to 7.7. I manually changed my `config.yaml` to use 7.7, so now I'm updating PuPHPet's version. I'm not family with the application's structure, so hopefully I updated everything that needs it.

Note: some of the other versions may be incorrect per https://www.linode.com/distributions