### PR TITLE
Fix for bindfs owner:group issue on synced folders

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
@@ -81,9 +81,11 @@ Vagrant.configure('2') do |config|
       sync_group = !folder['sync_group'].nil? ? folder['sync_group'] : 'www-data'
 
       if folder['sync_type'] == 'nfs'
-        config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
         if Vagrant.has_plugin?('vagrant-bindfs')
-          config.bindfs.bind_folder "#{folder['target']}", "/mnt/vagrant-#{i}"
+          config.vm.synced_folder "#{folder['source']}", "/mnt/vagrant-#{i}", id: "#{i}", type: 'nfs'
+          config.bindfs.bind_folder "/mnt/vagrant-#{i}", "#{folder['target']}", user: sync_owner, group: sync_group
+        else
+          config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
         end
       elsif folder['sync_type'] == 'smb'
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'smb'


### PR DESCRIPTION
A fix for issue #1319 : mounts the folder in /mnt/vagrant-xxx first, then
use bindfs to mount it to target destination with correct owner:group