### PR TITLE
Respect VAGRANT_DEFAULT_PROVIDER env var.

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
@@ -106,6 +106,10 @@ Vagrant.configure('2') do |config|
 
   config.vm.usable_port_range = (data['vm']['usable_port_range']['start'].to_i..data['vm']['usable_port_range']['stop'].to_i)
 
+  unless ENV.fetch('VAGRANT_DEFAULT_PROVIDER', '').strip.empty?
+    data['vm']['chosen_provider'] = ENV['VAGRANT_DEFAULT_PROVIDER'];
+  end
+
   if data['vm']['chosen_provider'].empty? || data['vm']['chosen_provider'] == 'virtualbox'
     ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 


### PR DESCRIPTION
Right now, puphpet disregards a user's `VAGRANT_DEFAULT_RPROVIDER` environment variable, which makes it impossible for devs working on a project together to use different providers depending on their local setup (VMware vs Virtualbox, for example).

This change makes a pre-set env var take precedence over the config.yaml file to allow per-developer provider overrides, just like vagrant itself expects.

This is a change in behavior, possibly backwards-incompatible, so some discussion may be warranted. I'm also unsure if this change might apply to other hosting services, or just local copies of vagrant.