### PR TITLE
Fixed Google Compute Engine zones list.

### DIFF
--- a/src/Puphpet/Extension/VagrantfileGceBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/VagrantfileGceBundle/Resources/config/available.yml
@@ -49,9 +49,9 @@ available_zones:
     asia-east1-a: asia-east1-a
     asia-east1-b: asia-east1-b
     asia-east1-c: asia-east1-c
-    asia-east1-c: asia-east1-c
     europe-west1-a: europe-west1-a (Deprecated)
     europe-west1-b: europe-west1-b
+    europe-west1-c: europe-west1-c
     us-central1-a: us-central1-a
     us-central1-b: us-central1-b
     us-central1-f: us-central1-f


### PR DESCRIPTION
* Removed duplicate entry for `asia-east1-c`
* Added missing entry for `europe-west1-c`

Used `gcloud compute zones list` to get an up-to-date listing.