### PR TITLE
Add bcmath and opcache php extensions.

### DIFF
--- a/src/Puphpet/Extension/PhpBundle/Resources/config/available.yml
+++ b/src/Puphpet/Extension/PhpBundle/Resources/config/available.yml
@@ -1,5 +1,6 @@
 available_modules:
     php:
+        - bcmath
         - cgi
         - cli
         - common
@@ -23,6 +24,7 @@ available_modules:
         - mysql
         - mysqlnd
         - odbc
+        - opcache
         - pspell
         - readline
         - recode


### PR DESCRIPTION
Currently it's not possible to add ```bcmath``` and ```opcache``` PHP extensions in the UI.
I haven't tested Ubuntu or Debian but on CentOS in PHP 5.5 and 5.6 PHP is compiled without ```--enable-bcmath``` and ```--enable-opcache```.