### PR TITLE
NFS permissions and owner fix

### DIFF
--- a/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
+++ b/src/Puphpet/Extension/VagrantfileLocalBundle/Resources/views/Vagrantfile.rb.twig
@@ -81,9 +81,11 @@ Vagrant.configure('2') do |config|
       sync_group = !folder['sync_group'].nil? ? folder['sync_group'] : 'www-data'
 
       if folder['sync_type'] == 'nfs'
-        config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
         if Vagrant.has_plugin?('vagrant-bindfs')
-          config.bindfs.bind_folder "#{folder['target']}", "/mnt/vagrant-#{i}"
+          config.vm.synced_folder "#{folder['source']}", "/mnt/vagrant-#{i}", id: "#{i}", type: 'nfs'
+          config.bindfs.bind_folder "/mnt/vagrant-#{i}", "#{folder['target']}", owner: sync_owner, group: sync_group, perms: "u=rwX:g=rwX:o=rD"
+        else
+          config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
         end
       elsif folder['sync_type'] == 'smb'
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'smb'


### PR DESCRIPTION
This pull request is a fix for #1378. With this, shared folders should already be assigned to www-data or whatever is assigned to sync_owner and not 501. Also added the perms option since I've checked that by default it is set to "u=rwX:g=rD:o=rD" which does not provide a write permission to anyone belonging to the www-data group (or any group assigned to sync_group).