### PR TITLE
Fix for #1406. Generate the .ini files for PECL extensions in a "standard" way

### DIFF
--- a/archive/puphpet/puppet/nodes/Php.pp
+++ b/archive/puphpet/puppet/nodes/Php.pp
@@ -135,6 +135,15 @@ if hash_key_equals($php_values, 'install', 1) {
         service_autorestart => $php_webserver_restart,
       }
     }
+    
+    puphpet::php::ini {"Generate INI files for PECL extension: ${name}":
+      entry        => 'PHP/extension',
+      value        => "${name}.so",
+      php_version  => $php_values['version'],
+      webserver    => $php_webserver_service_ini,
+      ini_filename => "${name}.ini",
+      require      => [Puphpet::Php::Pecl[$name]],
+    }
   }
 
   $php_inis = merge({


### PR DESCRIPTION
Fix for #1406. This uses your `puphpet::php::ini` code to generate .ini files in the appropriate directory (i.e. `mods-available` for Debian/Linux, etc). I will also submit a PR to remove the extraneous augeas code in your fork of `puphpet/puppet/modules/php/manifests/pecl/module.pp`