### PR TITLE
added an option to install Mysql Server 5.6 on Ubuntu 14.04

### DIFF
--- a/archive/puphpet/puppet/nodes/Mysql.pp
+++ b/archive/puphpet/puppet/nodes/Mysql.pp
@@ -31,6 +31,12 @@ if hash_key_equals($mysql_values, 'install', 1) {
     $mysql_server_require             = Exec['mysql-community-repo']
     $mysql_server_server_package_name = 'mysql-community-server'
     $mysql_server_client_package_name = 'mysql-community-client'
+  } elsif $mysql_values['version'] == '5.6' 
+    and $::lsbdistcodename == 'trusty'
+  {
+    $mysql_server_require             = []
+    $mysql_server_server_package_name = 'mysql-server-5.6'
+    $mysql_server_client_package_name = 'mysql-client-core-5.6'
   } else {
     $mysql_server_require             = []
     $mysql_server_server_package_name = $mysql::params::server_package_name


### PR DESCRIPTION
### What is the problem / feature ?

There is no easy way to install Mysql Server 5.6 on Ubuntu 14.04, the `mysql-server-5.6` does exist in in the universe apt repo, but under a versioned name, separate from the default. As far as I can tell there is no way to force load 5.6, besides overwriting both client and server packages.

### How did it get fixed / implemented ?

I added the overwrite based on `version: 5.6` setting in the `config.yaml` file. Best way to ensure that `config.yaml` doesn't grow (so without introducing 2 variables) and while maintaining uninterrupted puphpeting for most, I chose to add another condition to the server/client selection code. 

### How can someone test / see it ?

- replace the `Mysql.pp` code with contents of `Mysql.pp` in this PR
- add `version: 5.6` to your `mysql:` section of `puphpet/config.yaml` file
- vagrant up a `ubuntu-14.04` box
- run `mysqld --version`, output will be `mysqld  Ver 5.6.19-0ubuntu0.14.04.1 for debian-linux-gnu on x86_64 ((Ubuntu))`