### PR TITLE
Fix query params in Nginx conf

### DIFF
--- a/archive/puphpet/puppet/nodes/Nginx.pp
+++ b/archive/puphpet/puppet/nodes/Nginx.pp
@@ -85,7 +85,7 @@ if hash_key_equals($nginx_values, 'install', 1) {
         'locations'            => [
           {
             'location'              => '/',
-            'try_files'             => ['$uri', '$uri/', 'index.php',],
+            'try_files'             => ['$uri', '$uri/', 'index.php', '/index.php$is_args$args'],
             'fastcgi'               => '',
             'fastcgi_index'         => '',
             'fastcgi_split_path'    => '',

--- a/src/Puphpet/Extension/NginxBundle/Resources/config/defaults.yml
+++ b/src/Puphpet/Extension/NginxBundle/Resources/config/defaults.yml
@@ -33,6 +33,7 @@ vhosts:
                     - '$uri'
                     - '$uri/'
                     - 'index.php'
+                    - '/index.php$is_args$args'
                 fastcgi: ~
                 fastcgi_index: ~
                 fastcgi_split_path: ~


### PR DESCRIPTION
In the `location /` block in the `Nginx` config, it was ignoring query params (i.e. missing that `$is_args$args` business).

This was making it so if I had certain URLs, `$_GET` was always empty. i.e. `/?year=2015` would work, but `/log?year=2015` would have an empty `$_GET`.

It's in the `location ~ \.php$` block, and adding it to `location /` block fixes the issue for me.

I can't see any negative side-effects from this; in fact, I don't see any reason for it not to have been there.