### PR TITLE
Added Possibility to use Apache and Ngnix together

### DIFF
--- a/archive/puphpet/puppet/nodes/Apache.pp
+++ b/archive/puphpet/puppet/nodes/Apache.pp
@@ -208,9 +208,11 @@ if array_true($apache_values, 'install') {
     }
   }
 
-  class { 'puphpet::ssl_cert':
-    require => Class['apache'],
-    notify  => Service['httpd'],
+  if ! defined(Class["puphpet::ssl_cert"]) {
+    class { 'puphpet::ssl_cert':
+      require => Class['apache'],
+      notify  => Service['httpd'],
+    }
   }
 
   $default_vhost_index_file =


### PR DESCRIPTION
Hi,

I needed to configure Nginx as a Reverse Proxy for Apache. Therefore I changed the node files of them both to allow them beeing provisioned at the same time. Due to the limitations of Ngnix Proxy configuration the proxy part is done through a bash script.
The configuration is comparable to https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-as-a-reverse-proxy-for-apache

**The changes in the pull request enabled me to provision Ngnix, Apache and both together.**
The following config makes use of that. Mind the disabled default vhost in apache and that the configuratiion of Ngnix and Apache is not conflicting in terms of ports.
To use Nginx as a Reverse Proxy for Apache the script below is needed
 ```yaml
vagrantfile:
    target: local
    vm:
        box: puphpet/debian75-x64
        box_url: puphpet/debian75-x64
        hostname: ''
        memory: '1024'
        cpus: '4'
        chosen_provider: virtualbox
        network:
            private_network: 192.168.56.101
            forwarded_port:
                vflnp_lwhkblogibu1:
                    host: '9094'
                    guest: '22'
        post_up_message: ''
        provider:
            virtualbox:
                modifyvm:
                    natdnshostresolver1: on
            vmware:
                numvcpus: 1
            parallels:
                cpus: 1
        provision:
            puppet:
                manifests_path: puphpet/puppet
                manifest_file: site.pp
                module_path: puphpet/puppet/modules
                options:
                    - '--verbose'
                    - '--hiera_config /vagrant/puphpet/puppet/hiera.yaml'
                    - '--parser future'
        synced_folder:
            vflsf_qyt8qmlg3pvx:
                source: ../
                target: /var/www/shop.dev
                sync_type: nfs
                rsync:
                    args:
                        - '--verbose'
                        - '--archive'
                        - '-z'
                    exclude:
                        - .vagrant/
                        - .git/
                    auto: 'true'
                owner: www-data
                group: www-data
        usable_port_range:
            start: 10200
            stop: 10500
    ssh:
        host: null
        port: null
        private_key_path: null
        username: vagrant
        guest_port: null
        keep_alive: true
        forward_agent: false
        forward_x11: false
        shell: 'bash -l'
    vagrant:
        host: detect
server:
    install: '1'
    packages:
        - curl
        - vim
        - htop
        - iotop
        - sysstat
        - postgresql-contrib-9.4
users_groups:
    install: '1'
    groups: {  }
    users: {  }
firewall:
    install: '1'
    rules: {  }
cron:
    install: '1'
    jobs: {  }
nginx:
    install: '1'
    settings:
        default_vhost: 1
        proxy_buffer_size: 128k
        proxy_buffers: '4 256k'
    upstreams: {  }
    vhosts:
        nxv_zi74u9temq71:
            server_name: shop.dev
            server_aliases:
                - www.shop.dev
            www_root: /var/www/shop.dev/public
            listen_port: '80'
            index_files:
                - index.html
                - index.htm
                - index.php
            client_max_body_size: 1m
            ssl: '1'
            ssl_cert: ''
            ssl_key: ''
            ssl_port: '443'
            rewrite_to_https: '1'
            spdy: '0'
            locations:
                nxvl_5bdeod2q0dgg:
                    location: /
                    autoindex: off
                    try_files:
                        - $uri
                        - $uri/
                        - /index.php$is_args$args
                    fastcgi: ''
                    fastcgi_index: ''
                    fastcgi_split_path: ''
apache:
    install: '1'
    settings:
        user: www-data
        group: www-data
        default_vhost: false
        manage_user: false
        manage_group: false
        sendfile: 0
    modules:
        - proxy_fcgi
        - rewrite
    vhosts:
        av_ppcj3uqcesdm:
            servername: shop.dev
            serveraliases:
                - www.shop.dev
            docroot: /var/www/shop.dev/public
            port: '8080'
            setenv:
                - 'APPLICATION_ENV developement'
            custom_fragment: ''
            ssl_cert: ''
            ssl_key: ''
            ssl_chain: ''
            ssl_certs_dir: ''
            directories:
                avd_eukvcgg6dzfd:
                    path: /var/www/shop.dev/public
                    options:
                        - Indexes
                        - FollowSymlinks
                        - MultiViews
                    allow_override:
                        - All
                    require:
                        - 'all granted'
                    custom_fragment: ''
                    files_match:
                        avdfm_dpfi24dn0kiz:
                            path: \.php$
                            sethandler: 'proxy:fcgi://127.0.0.1:9000'
                            custom_fragment: ''
                            provider: filesmatch
                        avdfm_krlqvi4ghqsp:
                            path: \.phtml$
                            sethandler: 'proxy:fcgi://127.0.0.1:9000'
                            custom_fragment: ''
                            provider: filesmatch
                    provider: directory
php:
    install: '1'
    settings:
        version: '55'
    modules:
        php:
            - cli
            - intl
            - pgsql
        pear: {  }
        pecl:
            - pecl_http
    ini:
        display_errors: On
        error_reporting: '-1'
        session.save_path: /var/lib/php/session
        date.timezone: UTC
    fpm_ini:
        error_log: /var/log/php-fpm.log
    fpm_pools:
        phpfp_jq8g6weu23vn:
            ini:
                prefix: www
                listen: '127.0.0.1:9000'
                security.limit_extensions: .php
                user: www-user
                group: www-data
    composer: '1'
    composer_home: ''
xdebug:
    install: '1'
    settings:
        xdebug.default_enable: '1'
        xdebug.remote_autostart: '0'
        xdebug.remote_connect_back: '1'
        xdebug.remote_enable: '1'
        xdebug.remote_handler: dbgp
        xdebug.remote_port: '9000'
blackfire:
    install: '0'
    settings:
        server_id: ''
        server_token: ''
        agent:
            http_proxy: ''
            https_proxy: ''
            log_file: stderr
            log_level: '1'
        php:
            agent_timeout: '0.25'
            log_file: ''
            log_level: '1'
xhprof:
    install: '0'
wpcli:
    install: '0'
    version: v0.19.0
drush:
    install: '0'
    version: 6.3.0
ruby:
    install: '1'
    versions: {  }
python:
    install: '1'
    packages: {  }
    versions: {  }
nodejs:
    install: '0'
    npm_packages: {  }
hhvm:
    install: '0'
    nightly: 0
    composer: '1'
    composer_home: ''
    settings: {  }
    server_ini:
        hhvm.server.host: 127.0.0.1
        hhvm.server.port: '9000'
        hhvm.log.use_log_file: '1'
        hhvm.log.file: /var/log/hhvm/error.log
    php_ini:
        display_errors: On
        error_reporting: '-1'
        date.timezone: UTC
mysql:
    install: '0'
    settings:
        version: '5.6'
        root_password: '123'
        override_options: {  }
    adminer: 0
    users:
        mysqlnu_6vfkwlxq82g6:
            name: dbuser
            password: '123'
    databases:
        mysqlnd_ntwjros0lqyw:
            name: dbname
            sql: ''
    grants:
        mysqlng_ebfr8nbh5xmq:
            user: dbuser
            table: '*.*'
            privileges:
                - ALL
postgresql:
    install: '1'
    settings:
        global:
            encoding: UTF8
            version: '9.4'
        server:
            postgres_password: 123
    databases:
        postsqlnd_h31hjqs4knxb:
            dbname: dbname
            owner: dbuser
    users:
        postsqlnu_i667dlf1m6pm:
            username: dbuser
            password: 123
    grants: {  }
    adminer: 0
mongodb:
    install: '0'
    settings:
        auth: 1
        bind_ip: 127.0.0.1
        port: '27017'
    databases: {  }
redis:
    install: '0'
    settings:
        conf_port: '6379'
sqlite:
    install: '0'
    adminer: 0
    databases: {  }
mailcatcher:
    install: '0'
    settings:
        smtp_ip: 0.0.0.0
        smtp_port: 1025
        http_ip: 0.0.0.0
        http_port: '1080'
        mailcatcher_path: /usr/local/rvm/wrappers/default
        from_email_method: inline
beanstalkd:
    install: '0'
    settings:
        listenaddress: 0.0.0.0
        listenport: '13000'
        maxjobsize: '65535'
        maxconnections: '1024'
        binlogdir: /var/lib/beanstalkd/binlog
        binlogfsync: null
        binlogsize: '10485760'
    beanstalk_console: 0
    binlogdir: /var/lib/beanstalkd/binlog
rabbitmq:
    install: '0'
    settings:
        port: '5672'
    users: {  }
    vhosts: {  }
    plugins: {  }
elastic_search:
    install: '0'
    settings:
        version: 1.4.1
        java_install: true
solr:
    install: '0'
    settings:
        version: 4.10.2
        port: '8984'
```

puphpet/files/exec-always/50-vhost.sh
```bash
#!/bin/bash

NGNIX_PROXY="
  location ~ .phtml {
      proxy_set_header X-Real-IP  \$remote_addr;
      proxy_set_header X-Forwarded-For \$remote_addr;
      proxy_set_header Host \$host;
      proxy_pass http://127.0.0.1:8080;

  }
  location ~ .php$ {
      proxy_set_header X-Real-IP  \$remote_addr;
      proxy_set_header X-Forwarded-For \$remote_addr;
      proxy_set_header Host \$host;
      proxy_pass http://127.0.0.1:8080;

  }

  sendfile off ;"; 
NGNIX_PROXY=`echo ${NGNIX_PROXY} | tr '\n' "\\n"`

sudo sed -i "s|sendfile off;|${NGNIX_PROXY}|g" /etc/nginx/sites-enabled/*.conf
sudo sed -i "s|location ~ .phtml|location ~ \\\.phtml|g" /etc/nginx/sites-enabled/*.conf
sudo sed -i "s|location ~ .php|location ~ \\\.php|g" /etc/nginx/sites-enabled/*.conf

sudo /etc/init.d/nginx restart
```
