### PR TITLE
Honor group and owner for smb mounts

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -82,7 +82,8 @@ Vagrant.configure('2') do |config|
           config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
         end
       elsif folder['sync_type'] == 'smb'
-        config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'smb'
+        config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'smb',
+          group: sync_group, owner: sync_owner
       elsif folder['sync_type'] == 'rsync'
         rsync_args = !folder['rsync']['args'].nil? ? folder['rsync']['args'] : ['--verbose', '--archive', '-z']
         rsync_auto = !folder['rsync']['auto'].nil? ? folder['rsync']['auto'] : true


### PR DESCRIPTION
Vagrant supports specification of owner and group for smb shares:

[mount_smb_shared_folder.rb](https://github.com/mitchellh/vagrant/blob/4a9d99ef716c64e1098771632cb2ad6df5721cf7/plugins/guests/linux/cap/mount_smb_shared_folder.rb)
```ruby
          if options[:owner].is_a? Integer
            mount_uid = options[:owner]
          else
            mount_uid = "`id -u #{options[:owner]}`"
          end

          # ...

         mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"
```

This patch simply sets the owner/group from the puphpet config onto the config.vm.synced_folder option list. 