### PR TITLE
Change to saz/puppet-locales module

### DIFF
--- a/archive/puphpet/puppet/Puppetfile
+++ b/archive/puphpet/puppet/Puppetfile
@@ -34,8 +34,8 @@ mod 'puppetlabs/java',
     :git => 'https://github.com/puppetlabs/puppetlabs-java.git',
     :ref => '1.3.0'
 mod 'attachmentgenie/locales',
-    :git => 'https://github.com/attachmentgenie/attachmentgenie-locales.git',
-    :ref => '1.1.1'
+    :git => 'https://github.com/saz/puppet-locales.git',
+    :ref => 'v2.2.2'
 mod 'actionjack/mailcatcher',
     :git => 'https://github.com/puphpet/puppet-mailcatcher.git',
     :ref => 'dcc8c3d357'

--- a/archive/puphpet/puppet/nodes/Server.pp
+++ b/archive/puphpet/puppet/nodes/Server.pp
@@ -163,19 +163,19 @@ class puphpet_server (
   }
 
   if $::osfamily == 'debian' {
-    $default_value = array_true($locales, 'default_value') ? {
-      true    => $locales['default_value'],
+    $default_locale = array_true($locales_values, 'default_locale') ? {
+      true    => $locales_values['default_locale'],
       default => 'en_US.UTF-8'
     }
 
-    $available = array_true($locales, 'available') ? {
-      true    => $locales['default_value'],
+    $locales = array_true($locales_values, 'locales') ? {
+      true    => $locales_values['locales'],
       default => ['en_US.UTF-8 UTF-8', 'en_GB.UTF-8 UTF-8']
     }
 
-    $locales_settings = merge($locales, {
-      'default_value' => $default_value,
-      'available'     => $available,
+    $locales_settings = merge($locales_values, {
+      'default_locale' => $default_locale,
+      'locales'        => $locales,
     })
 
     create_resources('class', { 'locales' => $locales_settings })


### PR DESCRIPTION
Since you gave me the freedom to collaborate, come here send another PR. :smiley: 

This time on the issue https://github.com/puphpet/puphpet/issues/1620

This module is much better.
For example, for us Brazilians, it allows to set only LC_TIME as "pt_BR", avoiding major problems.

The current module allows only set the LC_ALL, which causes adverse effects.