### PR TITLE
Labels: Ubuntu 14.10 is not LTS and not Trusty

### DIFF
--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-digitalocean/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-digitalocean/available.yml
@@ -17,7 +17,7 @@ images:
             - HHVM
     -
         image: ubuntu-14-10-x64
-        long_name: Ubuntu Trusty 14.10 LTS x64
+        long_name: Ubuntu Utopic 14.10 x64
         php_versions:
             - 7.0
             - 5.6


### PR DESCRIPTION
Ubuntu 14.10 is not LTS and not called Trusty, only Ubuntu 14.04 is LTS and called Trusty
References: http://releases.ubuntu.com/14.04/ (Trusty LTS) and http://releases.ubuntu.com/14.10/ (Unicron)