### PR TITLE
Grammar fix

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/vagrantfile-local/form.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/vagrantfile-local/form.html.twig
@@ -152,9 +152,9 @@
 
         <div class="form-group col-xs-6">
             <div class="help-text">
-                Number of CPU's to assign to VM (only integers)
+                Number of CPUs to assign to VM (only integers)
             </div>
-            <label for="vagrantfile-vm-cpus">CPU's</label>
+            <label for="vagrantfile-vm-cpus">CPUs</label>
             <input type="number" id="vagrantfile-vm-cpus" name="vagrantfile[vm][cpus]"
                    placeholder="1" min="1" class="form-control"
                    value="{{ data.vm.cpus }}" />


### PR DESCRIPTION
CPUs is plural, not possessive.