### PR TITLE
Postgres failing to initialize: Error: $user_merged is :undef, not a hash or array

### DIFF
--- a/archive/puphpet/puppet/nodes/Postgresql.pp
+++ b/archive/puphpet/puppet/nodes/Postgresql.pp
@@ -73,7 +73,7 @@ class puphpet_postgresql (
     })
 
     create_resources( postgresql::server::role, {
-      "${user_merged['username']}" => $merged
+      "${merged['username']}" => $merged
     })
   }
 


### PR DESCRIPTION
Many things were changed in 8bae8a00101d49e303731af46f4a3aa6b889a333 but this variable was overseen which results in the given error. This commit/PR fixes this missed refactoring.

See https://github.com/puphpet/puphpet/commit/8bae8a00101d49e303731af46f4a3aa6b889a333#diff-22dc1c4de485f8beedda430c601474a1L77