### PR TITLE
Allow setting vm name from config.yaml

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -4,6 +4,11 @@ vagrant_dot  = (ENV['VAGRANT_DOTFILE_PATH'].to_s.split.join.length > 0) ? ENV['V
 Vagrant.configure('2') do |config|
   config.vm.box     = "#{data['vm']['box']}"
   config.vm.box_url = "#{data['vm']['box_url']}"
+  
+  if !data['vm']['name'].nil?
+    config.vm.define "#{data['vm']['name']}" do |t|
+    end
+  end
 
   if data['vm']['hostname'].to_s.strip.length != 0
     config.vm.hostname = "#{data['vm']['hostname']}"


### PR DESCRIPTION
This change allows you to set the name of the vm from config.yaml. This is useful when updating a project to a new server configuration. This way you can switch branches and will only have to suspend machines, not destroy them because of a conflicting name.

vagrantfile:
    vm:
        name: your_name_here

Do note I've only started working with vagrant & puphpet 2 days ago (specifically to help with this usecase). I might have overlooked a better way to do this.