### PR TITLE
use host names instead of aliases #1694

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -49,7 +49,7 @@ Vagrant.configure('2') do |config|
         hosts.push(vhost['server_name'])
 
         if vhost['server_aliases'].is_a?(Array)
-          vhost['server_aliases'].each do |x, vhost_alias|
+          vhost['server_aliases'].each do |vhost_alias|
             hosts.push(vhost_alias)
           end
         end


### PR DESCRIPTION
Currently indexes are pushed in the hosts array instead of value.

Applicable for vagrant + nginx + hostmanager setup.