### PR TITLE
Added MariaDB back to Puphpet

### DIFF
--- a/archive/puphpet/puppet/nodes/MariaDb.pp
+++ b/archive/puphpet/puppet/nodes/MariaDb.pp
@@ -1,0 +1,256 @@
+class puphpet_mariadb (
+  $mariadb,
+  $apache,
+  $nginx,
+  $php,
+  $hhvm
+) {
+
+  include puphpet::apache::params
+  include puphpet::mysql::params
+  include mysql::params
+
+  if array_true($apache, 'install') or array_true($nginx, 'install') {
+    $webserver_restart = true
+  } else {
+    $webserver_restart = false
+  }
+
+  $version = to_string($mariadb['settings']['version'])
+
+  class { 'puphpet::mariadb':
+    version => $version,
+  }
+
+  $server_package = $puphpet::params::mariadb_package_server_name
+  $client_package = $puphpet::params::mariadb_package_client_name
+
+  if array_true($php_values, 'install') {
+    $php_package = 'php'
+  } elsif array_true($hhvm_values, 'install') {
+    $php_package = 'hhvm'
+  } else {
+    $php_package = false
+  }
+
+  if empty($mariadb['settings']['root_password']) {
+    fail( 'MariaDB requires choosing a root password. Please check your config.yaml file.' )
+  }
+
+  $override_options = deep_merge($mysql::params::default_options, {
+    'mysqld' => {
+      'tmpdir' => $mysql::params::tmpdir,
+    }
+  })
+
+  $settings = delete(deep_merge({
+    'package_name'     => $server_package,
+    'restart'          => true,
+    'override_options' => $override_options,
+    'service_name'     => 'mysql',
+  }, $mariadb['settings']), 'version')
+
+  create_resources('class', {
+    'mysql::server' => $settings
+  })
+
+  class { 'mysql::client':
+    package_name => $client_package,
+  }
+
+  $mariadb_user = $override_options['mysqld']['user']
+
+  # Ensure the user exists
+  if ! defined(User[$mariadb_user]) {
+    user { $mariadb_user:
+      ensure => present,
+    }
+  }
+
+  # Ensure the group exists
+  if ! defined(Group[$mysql::params::root_group]) {
+    group { $mysql::params::root_group:
+      ensure => present,
+    }
+  }
+
+  # prevent problems with being unable to create dir in /tmp
+  if ! defined(File[$override_options['mysqld']['tmpdir']]) {
+    file { $override_options['mysqld']['tmpdir']:
+      ensure  => directory,
+      owner   => $mariadb_user,
+      group   => $mysql::params::root_group,
+      mode    => '0775',
+      require => Class['mysql::client'],
+      notify  => Service[$settings['service_name']]
+    }
+  }
+
+  # Ensure the data directory exists
+  if ! defined(File[$mysql::params::datadir]) {
+    file { $mysql::params::datadir:
+      ensure => directory,
+      group  => $mysql::params::root_group,
+      before => Class['mysql::server']
+    }
+  }
+
+  $mariadb_pidfile = $override_options['mysqld']['pid-file']
+
+  # Ensure PID file directory exists
+  exec { 'Create pidfile parent directory':
+    command => "mkdir -p $(dirname ${mariadb_pidfile})",
+    unless  => "test -d $(dirname ${mariadb_pidfile})",
+    before  => Class['mysql::server'],
+    require => [
+      User[$mariadb_user],
+      Group[$mysql::params::root_group]
+    ],
+  }
+  -> exec { 'Set pidfile parent directory permissions':
+    command => "chown \
+      ${mariadb_user}:${mysql::params::root_group} \
+      $(dirname ${mariadb_pidfile})",
+  }
+
+  Mysql_user <| |>
+  -> Mysql_database <| |>
+  -> Mysql_grant <| |>
+
+  # config file could contain no users key
+  $users = array_true($mariadb, 'users') ? {
+    true    => $mariadb['users'],
+    default => { }
+  }
+
+  each( $users ) |$key, $user| {
+    # if no host passed with username, default to localhost
+    if '@' in $user['name'] {
+      $name = $user['name']
+    } else {
+      $name = "${user['name']}@localhost"
+    }
+
+    # force to_string to convert possible ints
+    $password_hash = mysql_password(to_string($user['password']))
+
+    $merged = delete(merge($user, {
+      ensure          => 'present',
+      'password_hash' => $password_hash,
+    }), ['name', 'password'])
+
+    create_resources( mysql_user, { "${name}" => $merged })
+  }
+
+  # config file could contain no databases key
+  $databases = array_true($mariadb, 'databases') ? {
+    true    => $mariadb['databases'],
+    default => { }
+  }
+
+  each( $databases ) |$key, $database| {
+    $name = $database['name']
+    $sql  = $database['sql']
+
+    $import_timeout = array_true($database, 'import_timeout') ? {
+      true    => $database['import_timeout'],
+      default => 300
+    }
+
+    $merged = delete(merge($database, {
+      ensure => 'present',
+    }), ['name', 'sql', 'import_timeout'])
+
+    create_resources( mysql_database, { "${name}" => $merged })
+
+    if $sql {
+      # Run import only on initial database creation
+      $touch_file = "/.puphpet-stuff/db-import-${name}"
+
+      exec{ "${name}-import":
+        command     => "mysql ${name} < ${sql} && touch ${touch_file}",
+        creates     => $touch_file,
+        logoutput   => true,
+        environment => "HOME=${::root_home}",
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin',
+        timeout     => $import_timeout,
+        require     => Mysql_database[$name]
+      }
+    }
+  }
+
+  # config file could contain no grants key
+  $grants = array_true($mariadb, 'grants') ? {
+    true    => $mariadb['grants'],
+    default => { }
+  }
+
+  each( $grants ) |$key, $grant| {
+    # if no host passed with username, default to localhost
+    if '@' in $grant['user'] {
+      $user = $grant['user']
+    } else {
+      $user = "${grant['user']}@localhost"
+    }
+
+    $table = $grant['table']
+
+    $name = "${user}/${table}"
+
+    $options = array_true($grant, 'options') ? {
+      true    => $grant['options'],
+      default => ['GRANT']
+    }
+
+    $merged = merge($grant, {
+      ensure    => 'present',
+      'user'    => $user,
+      'options' => $options,
+    })
+
+    create_resources( mysql_grant, { "${name}" => $merged })
+  }
+
+  if $php_package == 'php' {
+    if $::osfamily == 'redhat' and $php['settings']['version'] == '53' {
+      $php_module = 'mysql'
+    } elsif $::lsbdistcodename == 'lucid' or $::lsbdistcodename == 'squeeze' {
+      $php_module = 'mysql'
+    } else {
+      $php_module = 'mysqlnd'
+    }
+
+    if ! defined(Puphpet::Php::Module[$php_module]) {
+      puphpet::php::module { $php_module:
+        service_autorestart => $webserver_restart,
+      }
+    }
+  }
+
+  if array_true($mariadb, 'adminer')
+    and $php_package
+    and ! defined(Class['puphpet::adminer'])
+  {
+    $apache_webroot = $puphpet::apache::params::default_vhost_dir
+    $nginx_webroot  = $puphpet::params::nginx_webroot_location
+
+    if array_true($apache, 'install') {
+      $adminer_webroot = $apache_webroot
+      Class['puphpet_apache']
+      -> Class['puphpet::adminer']
+    } elsif array_true($nginx, 'install') {
+      $adminer_webroot = $nginx_webroot
+      Class['puphpet_nginx']
+      -> Class['puphpet::adminer']
+    } else {
+      fail( 'Adminer requires either Apache or Nginx to be installed.' )
+    }
+
+    class { 'puphpet::adminer':
+      location    => "${$adminer_webroot}/adminer",
+      owner       => 'www-data',
+      php_package => $php_package
+    }
+  }
+
+}

--- a/archive/puphpet/puppet/site.pp
+++ b/archive/puphpet/puppet/site.pp
@@ -13,6 +13,7 @@ $firewall       = hiera_hash('firewall', {})
 $hhvm           = hiera_hash('hhvm', {})
 $locales        = hiera_hash('locales', {})
 $mailcatcher    = hiera_hash('mailcatcher', {})
+$mariadb        = hiera_hash('mariadb', {})
 $mongodb        = hiera_hash('mongodb', {})
 $mysql          = hiera_hash('mysql', {})
 $nginx          = $yaml['nginx']
@@ -91,6 +92,16 @@ if array_true($mailcatcher, 'install') {
   }
 }
 
+if array_true($mariadb, 'install') and ! array_true($mysql, 'install') {
+  class { '::puphpet_mariadb':
+    mariadb => $mariadb,
+    apache  => $apache,
+    nginx   => $nginx,
+    php     => $php,
+    hhvm    => $hhvm
+  }
+}
+
 if array_true($mongodb, 'install') {
   class { '::puphpet_mongodb':
     mongodb => $mongodb,
@@ -100,7 +111,7 @@ if array_true($mongodb, 'install') {
   }
 }
 
-if array_true($mysql, 'install') {
+if array_true($mysql, 'install') and ! array_true($mariadb, 'install') {
   class { '::puphpet_mysql':
     mysql  => $mysql,
     apache => $apache,

--- a/src/Puphpet/MainBundle/Controller/MariaDbController.php
+++ b/src/Puphpet/MainBundle/Controller/MariaDbController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Puphpet\MainBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class MariaDbController extends Controller
+{
+    public function indexAction(array $data)
+    {
+        return $this->render('PuphpetMainBundle:mariadb:form.html.twig', [
+            'mariadb'              => $data,
+            'available_privileges' => $this->getData()['privileges'],
+        ]);
+    }
+
+    public function addUserAction()
+    {
+        return $this->render('PuphpetMainBundle:mariadb/sections:user.html.twig', [
+            'user' => $this->getData()['empty_user'],
+        ]);
+    }
+
+    public function addDatabaseAction()
+    {
+        return $this->render('PuphpetMainBundle:mariadb/sections:database.html.twig', [
+            'database' => $this->getData()['empty_database'],
+        ]);
+    }
+
+    public function addGrantAction()
+    {
+        return $this->render('PuphpetMainBundle:mariadb/sections:grant.html.twig', [
+            'grant'                => $this->getData()['empty_grant'],
+            'available_privileges' => $this->getData()['privileges'],
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    private function getData()
+    {
+        $manager = $this->get('puphpet.extension.manager');
+        return $manager->getExtensionAvailableData('mariadb');
+    }
+}

--- a/src/Puphpet/MainBundle/Resources/config/mariadb/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/mariadb/available.yml
@@ -1,0 +1,53 @@
+versions:
+    - "10.0"
+    - "5.5"
+
+privileges:
+    "Give all":
+        - ALL
+    "or, Give some":
+        - ALTER
+        - ALTER ROUTINE
+        - CREATE
+        - CREATE ROUTINE
+        - CREATE TABLESPACE
+        - CREATE TEMPORARY TABLES
+        - CREATE USER
+        - CREATE VIEW
+        - DELETE
+        - DROP
+        - EVENT
+        - EXECUTE
+        - FILE
+        - GRANT OPTION
+        - INDEX
+        - INSERT
+        - LOCK TABLES
+        - PROCESS
+        - PROXY
+        - REFERENCES
+        - RELOAD
+        - REPLICATION CLIENT
+        - REPLICATION SLAVE
+        - SELECT
+        - SHOW DATABASES
+        - SHOW VIEW
+        - SHUTDOWN
+        - SUPER
+        - TRIGGER
+        - UPDATE
+        - USAGE
+
+empty_user:
+    name: ~
+    password: ~
+
+empty_database:
+    name: ~
+    sql: ~
+
+empty_grant:
+    user: ~
+    table: '*.*'
+    privileges:
+        - ALL

--- a/src/Puphpet/MainBundle/Resources/config/mariadb/data.yml
+++ b/src/Puphpet/MainBundle/Resources/config/mariadb/data.yml
@@ -1,0 +1,13 @@
+install: 0
+settings:
+    version: "10.0"
+    root_password: 123
+    override_options: {}
+
+adminer: 0
+
+users: []
+
+databases: []
+
+grants: []

--- a/src/Puphpet/MainBundle/Resources/config/mariadb/defaults.yml
+++ b/src/Puphpet/MainBundle/Resources/config/mariadb/defaults.yml
@@ -1,0 +1,22 @@
+install: 0
+
+settings:
+    version: "10.0"
+    override_options: {}
+
+users:
+    -
+        name: dbuser
+        password: 123
+
+databases:
+    -
+        name: dbname
+        sql: ~
+
+grants:
+    -
+        user: dbuser
+        table: '*.*'
+        privileges:
+            - ALL

--- a/src/Puphpet/MainBundle/Resources/config/mariadb/routing.yml
+++ b/src/Puphpet/MainBundle/Resources/config/mariadb/routing.yml
@@ -1,0 +1,15 @@
+puphpet.mariadb.homepage:
+    pattern:  /
+    defaults: { _controller: PuphpetMainBundle:MariaDb:index }
+
+puphpet.mariadb.add_user:
+    pattern:  /add-user
+    defaults: { _controller: PuphpetMainBundle:MariaDb:addUser }
+
+puphpet.mariadb.add_database:
+    pattern:  /add-database
+    defaults: { _controller: PuphpetMainBundle:MariaDb:addDatabase }
+
+puphpet.mariadb.add_grant:
+    pattern:  /add-grant
+    defaults: { _controller: PuphpetMainBundle:MariaDb:addGrant }

--- a/src/Puphpet/MainBundle/Resources/config/routing.yml
+++ b/src/Puphpet/MainBundle/Resources/config/routing.yml
@@ -95,6 +95,9 @@ puphpet.hhvm:
 puphpet.mysql:
     resource: "@PuphpetMainBundle/Resources/config/mysql/routing.yml"
     prefix:   /extension/mysql
+puphpet.mariadb:
+    resource: "@PuphpetMainBundle/Resources/config/mariadb/routing.yml"
+    prefix:   /extension/mariadb
 puphpet.postgresql:
     resource: "@PuphpetMainBundle/Resources/config/postgresql/routing.yml"
     prefix:   /extension/postgresql

--- a/src/Puphpet/MainBundle/Resources/config/services.yml
+++ b/src/Puphpet/MainBundle/Resources/config/services.yml
@@ -35,6 +35,7 @@ services:
             - [ addExtension, [ 'hhvm' ] ]
         # database
             - [ addExtension, [ 'mysql' ] ]
+            - [ addExtension, [ 'mariadb' ] ]
             - [ addExtension, [ 'postgresql' ] ]
             - [ addExtension, [ 'mongodb' ] ]
             - [ addExtension, [ 'redis' ] ]

--- a/src/Puphpet/MainBundle/Resources/views/front/sections/database.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/sections/database.html.twig
@@ -1,6 +1,9 @@
 <div class="tab-pane" id="mysql">
     {% include 'PuphpetMainBundle:mysql:form.html.twig' with {'mysql': add_available(extensions.mysql.merged, extensions.mysql.available)} %}
 </div>
+<div class="tab-pane" id="mariadb">
+    {% include 'PuphpetMainBundle:mariadb:form.html.twig' with {'mariadb': add_available(extensions.mariadb.merged, extensions.mariadb.available)} %}
+</div>
 <div class="tab-pane" id="postgresql">
     {% include 'PuphpetMainBundle:postgresql:form.html.twig' with {'postgresql': add_available(extensions.postgresql.merged, extensions.postgresql.available)} %}
 </div>

--- a/src/Puphpet/MainBundle/Resources/views/front/side-menu.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/front/side-menu.html.twig
@@ -69,6 +69,7 @@
                 </a>
                 <ul class="sub">
                     <li><a href="#mysql" data-toggle="tab"> MySQL </a></li>
+                    <li><a href="#mariadb" data-toggle="tab"> MariaDB </a></li>
                     <li><a href="#postgresql" data-toggle="tab"> PostgreSQL </a></li>
                     <li><a href="#mongodb" data-toggle="tab"> MongoDB </a></li>
                     <li><a href="#redis" data-toggle="tab"> Redis </a></li>

--- a/src/Puphpet/MainBundle/Resources/views/mariadb/form.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/mariadb/form.html.twig
@@ -1,32 +1,32 @@
-{% set selectedVersion = (mysql.settings.version is defined and mysql.settings.version)
-    ? mysql.settings.version
+{% set selectedVersion = (mariadb.settings.version is defined and mariadb.settings.version)
+    ? mariadb.settings.version
     : false %}
 {% set versions = selectedVersion
-    ? merge_unique([selectedVersion], mysql.available.versions)
-    : mysql.available.versions %}
+    ? merge_unique([selectedVersion], mariadb.available.versions)
+    : mariadb.available.versions %}
 
-<input type="hidden" name="mysql[install]" value="0" />
+<input type="hidden" name="mariadb[install]" value="0" />
 
-<div class="section-header">
-    <h1>MySQL</h1>
-    <p class="lead">Install MySQL and create users and databases.</p>
+<div class="section-header hidden">
+    <h1>MariaDB</h1>
+    <p class="lead">Install MariaDB and create users and databases.</p>
 </div>
 
 <div class="field-container">
     <div class="form-group">
         <label class="col-xs-12 radio-tile">
-            <input type="checkbox" name="mysql[install]" value="1"
+            <input type="checkbox" name="mariadb[install]" value="1"
                    class="invisible toggle-on-select update-other-input-on-check"
-                   {% if mysql.install %}checked{% endif %}
-                   data-vis-toggle-target="#mysql-container"
-                   data-update-on-check-mariadb[install]="0" />
+                   {% if mariadb.install %}checked{% endif %}
+                   data-vis-toggle-target="#mariadb-container"
+                   data-update-on-check-mysql[install]="0" />
             <span class="content">
                 <span class="header large">
                     <i class="icon"></i>
-                    <span class="title">Install MySQL</span>
+                    <span class="title">Install MariaDB</span>
                 </span>
                 <span class="footer">
-                    The world's most popular open source database. If you install MySQL, you cannot install MariaDB.
+                    If you install MariaDB, you cannot install MySQL.
                 </span>
             </span>
         </label>
@@ -36,14 +36,14 @@
 
     <div class="clearfix"></div>
 
-    <div id="mysql-container" class="{% if not mysql.install %}hidden{% endif %}">
+    <div id="mariadb-container" class="{% if not mariadb.install %}hidden{% endif %}">
         <div class="form-group col-xs-6">
             <div class="clearfix"><label>Version</label></div>
 
             {% for version in versions %}
                 <label class="radio-tile mini set-width">
                     <input type="radio" class="invisible"
-                           name="mysql[settings][version]"
+                           name="mariadb[settings][version]"
                            value="{{ version }}"
                            {% if version == selectedVersion %}checked{% endif %} />
                     <span class="content">
@@ -66,11 +66,11 @@
                 <strong>Database will only be installed
                 when a password is entered here.</strong>
             </div>
-            <label for="mysql-settings-root_password">Root Password</label>
-            <input type="text" id="mysql-settings-root_password"
-                   name="mysql[settings][root_password]"
+            <label for="mariadb-settings-root_password">Root Password</label>
+            <input type="text" id="mariadb-settings-root_password"
+                   name="mariadb[settings][root_password]"
                    placeholder="/path/to/your/web/files" class="form-control"
-                   value="{{ mysql.settings.root_password }}" />
+                   value="{{ mariadb.settings.root_password }}" />
         </div>
 
         <div class="clearfix"></div>
@@ -86,9 +86,9 @@
                     If installed it will be available from
                     <code>http://{SERVER_IP_ADDRESS}/adminer</code>.
                 </span>
-                <input type="checkbox" name="mysql[adminer]"
+                <input type="checkbox" name="mariadb[adminer]"
                        class="invisible"
-                       {% if mysql.adminer %}checked{% endif %}
+                       {% if mariadb.adminer %}checked{% endif %}
                        value="1" />
                 <span class="content">
                     <span class="header">
@@ -104,7 +104,7 @@
                 application like
                 <a href="http://www.sequelpro.com/" target="_blank">Sequel Pro (OS X)</a>,
                 <a href="http://www.heidisql.com/" target="_blank">HeidiSQL (Windows)</a>, and
-                <a href="http://dev.mysql.com/downloads/tools/workbench/"
+                <a href="http://dev.mariadb.com/downloads/tools/workbench/"
                    target="_blank">MySQL Workbench (Cross Platform)</a>.</p>
             <p>Connect using SSH tunnel, username <code>vagrant</code> and SSH key generated at
                 <code>puphpet/files/dot/ssh/id_rsa</code>. This key is generated <strong>after</strong>
@@ -113,39 +113,37 @@
 
         <div class="clearfix"></div>
 
-        {% for user in mysql.users %}
-            {% include 'PuphpetMainBundle:mysql/sections:user.html.twig' with {'user': user} %}
+        {% for user in mariadb.users %}
+            {% include 'PuphpetMainBundle:mariadb/sections:user.html.twig' with {'user': user} %}
         {% endfor %}
 
-        <a href="#" data-source-url="{{ path('puphpet.mysql.add_user') }}"
+        <a href="#" data-source-url="{{ path('puphpet.mariadb.add_user') }}"
            class="add-block"><i class="fa fa-level-up fa-rotate-90"></i> Add another user</a>
 
-        {% for database in mysql.databases %}
-            {% include 'PuphpetMainBundle:mysql/sections:database.html.twig' with {'database': database} %}
+        {% for database in mariadb.databases %}
+            {% include 'PuphpetMainBundle:mariadb/sections:database.html.twig' with {'database': database} %}
         {% endfor %}
 
-        <a href="#" data-source-url="{{ path('puphpet.mysql.add_database') }}"
+        <a href="#" data-source-url="{{ path('puphpet.mariadb.add_database') }}"
            class="add-block"><i class="fa fa-level-up fa-rotate-90"></i> Add another database</a>
 
-        {% for grant in mysql.grants %}
-            {% include 'PuphpetMainBundle:mysql/sections:grant.html.twig' with {
-                'available_privileges': mysql.available.privileges, 'grant': grant} %}
+        {% for grant in mariadb.grants %}
+            {% include 'PuphpetMainBundle:mariadb/sections:grant.html.twig' with {
+                'available_privileges': mariadb.available.privileges, 'grant': grant} %}
         {% endfor %}
 
-        <a href="#" data-source-url="{{ path('puphpet.mysql.add_grant') }}"
+        <a href="#" data-source-url="{{ path('puphpet.mariadb.add_grant') }}"
            class="add-block"><i class="fa fa-level-up fa-rotate-90"></i> Add another grant</a>
     </div>
 
-    <div class="clearfix"></div>
-
     <div class="col-xs-6">
-        <a class="btn btn-lg btn-success btn-block next-section" type="button" href="#hhvm">
-            <i class="fa fa-hand-o-left"></i> HHVM
+        <a class="btn btn-lg btn-success btn-block next-section" type="button" href="#mysql">
+            <i class="fa fa-hand-o-left"></i> MySQL
         </a>
     </div>
     <div class="col-xs-6">
-        <a class="btn btn-lg btn-success btn-block next-section" type="button" href="#mariadb">
-            MariaDB <i class="fa fa-hand-o-right"></i>
+        <a class="btn btn-lg btn-success btn-block next-section" type="button" href="#postgresql">
+            PostgreSQL <i class="fa fa-hand-o-right"></i>
         </a>
     </div>
 

--- a/src/Puphpet/MainBundle/Resources/views/mariadb/sections/database.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/mariadb/sections/database.html.twig
@@ -1,0 +1,31 @@
+{% set uniqid = uniqid('mariadbnd_', true) %}
+
+<div class="nested-block" id="{{ uniqid }}">
+    <a href="#" class="delete-block remove"
+       data-block-id="{{ uniqid }}"><i class="fa fa-times"></i></a>
+    <fieldset>
+        <legend>Create Database</legend>
+
+        <div class="form-group col-xs-6">
+            <label for="mariadb-databases-{{ uniqid }}-name">DB Name</label>
+            <input type="text" id="mariadb-databases-{{ uniqid }}-name"
+                   name="mariadb[databases][{{ uniqid }}][name]"
+                   placeholder="database_name" class="form-control"
+                   value="{{ database.name }}" />
+        </div>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                Optional. Make sure this file is inside the VM,
+                or is inside a shared folder before running <code>$ vagrant up</code>
+            </div>
+            <label for="mariadb-databases-{{ uniqid }}-sql">Import Database From File</label>
+            <input type="text" id="mariadb-databases-{{ uniqid }}-sql"
+                   name="mariadb[databases][{{ uniqid }}][sql]"
+                   placeholder="123" class="form-control"
+                   value="{{ database.sql }}" />
+        </div>
+
+        <div class="clearfix"></div>
+    </fieldset>
+</div>

--- a/src/Puphpet/MainBundle/Resources/views/mariadb/sections/grant.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/mariadb/sections/grant.html.twig
@@ -1,0 +1,63 @@
+{% set uniqid = uniqid('mariadbng_', true) %}
+
+<div class="nested-block" id="{{ uniqid }}">
+    <a href="#" class="delete-block remove"
+       data-block-id="{{ uniqid }}"><i class="fa fa-times"></i></a>
+    <fieldset>
+        <legend>Additional Grant</legend>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                User must be defined in section above!
+            </div>
+            <label for="mariadb-grants-{{ uniqid }}-user">User</label>
+            <input type="text" id="mariadb-grants-{{ uniqid }}-user"
+                   name="mariadb[grants][{{ uniqid }}][user]"
+                   placeholder="user" class="form-control"
+                   value="{{ grant.user }}" />
+        </div>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                Can be <code>*.*</code> for all databases/tables,
+                <code>{database}.*</code> for all tables in a specific
+                database, or <code>{database}.{table}</code> for a
+                specific table in a specific database.
+            </div>
+            <label for="mariadb-grants-{{ uniqid }}-table">Database</label>
+            <input type="text" id="mariadb-grants-{{ uniqid }}-table"
+                   name="mariadb[grants][{{ uniqid }}][table]"
+                   placeholder="*.*" class="form-control"
+                   value="{{ grant.table }}" />
+        </div>
+
+        <div class="clearfix"></div>
+
+        <div class="form-group col-xs-12">
+            <div class="help-text">
+                Choose "All" or a mix of the others.
+            </div>
+            <label for="mariadb-grants-{{ uniqid }}-privileges">Privileges</label>
+            <select id="mariadb-grants-{{ uniqid }}-privileges"
+                   multiple name="mariadb[grants][{{ uniqid }}][privileges][]"
+                   class="form-control select-tags-editable">
+                {% set flattened = [] %}
+                {% for type, privileges in available_privileges %}
+                    <optgroup label="{{ type }}">
+                        {% for privilege in privileges %}
+                            {% set flattened = flattened|merge([privilege]) %}
+                            <option value="{{ privilege }}"
+                                {% if privilege in grant.privileges %}selected{% endif %}>{{ privilege }}</option>
+                        {% endfor %}
+                    </optgroup>
+                {% endfor %}
+
+                {% for privilege in grant.privileges %}
+                    {% if privilege not in flattened %}
+                        <option value="{{ privilege }}" selected>{{ privilege }}</option>
+                    {% endif %}
+                {% endfor %}
+            </select>
+        </div>
+    </fieldset>
+</div>

--- a/src/Puphpet/MainBundle/Resources/views/mariadb/sections/user.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/mariadb/sections/user.html.twig
@@ -1,0 +1,37 @@
+{% set uniqid = uniqid('mariadbnu_', true) %}
+
+<div class="nested-block" id="{{ uniqid }}">
+    <a href="#" class="delete-block remove"
+       data-block-id="{{ uniqid }}"><i class="fa fa-times"></i></a>
+    <fieldset>
+        <legend>Create User</legend>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                Enter <code>{username}@{host}</code>
+                for a specific host. If no host is defined, eg:
+                <code>{username}</code>", it will
+                automagically be converted to
+                <code>{username}@localhost</code>
+            </div>
+            <label for="mariadb-users-{{ uniqid }}-name">Username</label>
+            <input type="text" id="mariadb-users-{{ uniqid }}-name"
+                   name="mariadb[users][{{ uniqid }}][name]"
+                   placeholder="name" class="form-control"
+                   value="{{ user.name }}" />
+        </div>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                Password is required for each user.
+            </div>
+            <label for="mariadb-users-{{ uniqid }}-password">Password</label>
+            <input type="text" id="mariadb-users-{{ uniqid }}-password"
+                   name="mariadb[users][{{ uniqid }}][password]"
+                   placeholder="123" class="form-control"
+                   value="{{ user.password }}" />
+        </div>
+
+        <div class="clearfix"></div>
+    </fieldset>
+</div>


### PR DESCRIPTION
Fixed #835.
Replaces #1514 due to sloppiness of previous branch.

I've made a new branch without the messiness of the new UI merging.
This should add MariaDB support back into Puphpet.
In the long run, MariaDB and MySQL should really be run off of the same code set, but for now have basically "almost" copy + pasted code except for a few MariaDB hiccups that must be accounted for.