### PR TITLE
Makes public network work

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -14,7 +14,10 @@ Vagrant.configure('2') do |config|
   end
   
   if data['vm']['network']['public_network'].to_s != ''
-    config.vm.network 'public_network', ip: "#{data['vm']['network']['public_network']}"
+    config.vm.network 'public_network'
+    if data['vm']['network']['public_network'].to_s != '1'
+      config.vm.network 'public_network', ip: "#{data['vm']['network']['public_network']}"
+    end
   end
 
   data['vm']['network']['forwarded_port'].each do |i, port|


### PR DESCRIPTION
At first I had a problem with getting public network to work which this code at line 17 solves:
`config.vm.network 'public_network'`
Later on I added an if statement to check if 1 was set as a value for the public_network variable in config.yaml.

public_network: '1' - if you want to enable public network
public_network: '192.168.33.10' - to enable public network AND set a static ip

I'm no ruby programmer and I cannot understand why this isn't already working. My code does solves it for me and also adds the option to opt out the static ip setting and still have a public network.