### PR TITLE
Change DigitalOcean default Vagrantfile so that it works

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-digitalocean
+++ b/archive/puphpet/vagrant/Vagrantfile-digitalocean
@@ -5,10 +5,12 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = "#{data['vm']['hostname']}"
   config.nfs.functional = false
 
-  config.ssh.private_key_path = "#{data['ssh']['private_key_path']}"
-  config.ssh.username         = "#{data['ssh']['username']}"
+  if !data['ssh']['username'].nil?
+    config.ssh.username         = "#{data['ssh']['username']}"
+  end
 
-  config.vm.provider :digital_ocean do |provider|
+  config.vm.provider :digital_ocean do |provider, override|
+    override.ssh.private_key_path = "#{data['ssh']['private_key_path']}"
     provider.token        = "#{data['vm']['provider']['digital_ocean']['token']}"
     provider.image        = "#{data['vm']['provider']['digital_ocean']['image']}"
     provider.region       = "#{data['vm']['provider']['digital_ocean']['region']}"


### PR DESCRIPTION
Following the documentation of the digitalocean provider plugin at https://github.com/smdahlen/vagrant-digitalocean the changes in this PR are required so that the config.yaml produced by puphet is used correctly and a VM can be spun up at DigitalOcean correctly with the root linux user being used, instead of creating a new user in the box.