### PR TITLE
PHP 5.5 support

### DIFF
--- a/src/Puphpet/MainBundle/Extension/Archive.php
+++ b/src/Puphpet/MainBundle/Extension/Archive.php
@@ -4,7 +4,6 @@ namespace Puphpet\MainBundle\Extension;
 
 class Archive
 {
-    const ARCHIVE_LOCATION = __DIR__ . '/../../../../archive';
 
     /**
      * @var string Location of existing, empty files
@@ -36,7 +35,7 @@ class Archive
     public function getSourceDir()
     {
         if (!$this->sourceDir) {
-            $this->sourceDir = sprintf('%s/%s', self::ARCHIVE_LOCATION, $this->subDir);
+            $this->sourceDir = sprintf('%s/%s', $this->getArchiveLocation(), $this->subDir);
         }
 
         return $this->sourceDir;
@@ -195,5 +194,15 @@ class Archive
     protected function file_put_contents($filename, $data, $flags = null)
     {
         return file_put_contents($filename, $data, $flags);
+    }
+
+    /**
+     * Get the default archive location.
+     *
+     * @return string
+     */
+    protected function getArchiveLocation()
+    {
+        return __DIR__ . '/../../../../archive';
     }
 }

--- a/src/Puphpet/MainBundle/Extension/Manager.php
+++ b/src/Puphpet/MainBundle/Extension/Manager.php
@@ -17,8 +17,11 @@ class Manager
     /** @var array */
     protected $extensions = [];
 
-    public function __construct($confDir = __DIR__ . '/../Resources/config')
+    public function __construct($confDir = null)
     {
+        if (is_null($confDir)) {
+          $confDir = __DIR__ . '/../Resources/config';
+        }
         $this->confDir = $confDir;
     }
 

--- a/src/Puphpet/MainBundle/Tests/Unit/MainBundle/Extension/ManagerTest.php
+++ b/src/Puphpet/MainBundle/Tests/Unit/MainBundle/Extension/ManagerTest.php
@@ -104,13 +104,13 @@ class ManagerTest extends Unit\BaseTest
     {
         $this->setExpectedException(Exception\ParseException::class);
 
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('extension-broken');
     }
 
     public function testAddExtensionConvertsExtensionNameDashToUnderscore()
     {
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('vagrantfile-local');
 
         $extensionsArray = $manager->getExtensions();
@@ -126,7 +126,7 @@ class ManagerTest extends Unit\BaseTest
 
     public function testAddExtensionSetsDataInDefaultsAndDataKeys()
     {
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('vagrantfile-local');
 
         $extOneData = $this->configs['vagrantfile-local'];
@@ -139,7 +139,7 @@ class ManagerTest extends Unit\BaseTest
 
     public function testAddExtensionMergesDataDefaultsAndAvailableData()
     {
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('vagrantfile-local');
 
         $extOneData = $this->configs['vagrantfile-local'];
@@ -156,7 +156,7 @@ class ManagerTest extends Unit\BaseTest
 
     public function testAddExtensionHandlesMultipleExtensions()
     {
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('vagrantfile-local');
         $manager->addExtension('php');
         $manager->addExtension('vagrantfile-rackspace');
@@ -168,16 +168,21 @@ class ManagerTest extends Unit\BaseTest
 
     public function testSetCustomDataAllOverridesDefaultData()
     {
-        $manager = new Manager(self::CONF_DIR);
+        $manager = new Manager($this->getConfDir());
         $manager->addExtension('vagrantfile-local');
         $manager->addExtension('vagrantfile-rackspace');
 
-        $customData = Yaml::parse(self::CONF_DIR . '/custom-data/custom.yml');
+        $customData = Yaml::parse($this->getConfDir() . '/custom-data/custom.yml');
 
         $manager->setCustomDataAll($customData);
 
-        $expectedResult = Yaml::parse(self::CONF_DIR . '/custom-data/expected-merged.yml');
+        $expectedResult = Yaml::parse($this->getConfDir() . '/custom-data/expected-merged.yml');
 
         $this->assertEquals($expectedResult, $manager->getExtensions());
+    }
+
+    protected function getConfDir()
+    {
+        return Unit\BaseTest::BASE_TEST_DIR . '/assets/config';
     }
 }


### PR DESCRIPTION
The only thing stopping PuPHPet from being compatible with PHP 5.5 is that it uses expressions in one constant declaration and one default argument. This PR removes those.  Seeing as PHP 5.5 is the default version for Ubuntu 14.04 LTS this is useful for those deploying to their own infrastructure.