### PR TITLE
Add AWS options for subnet_id and elastic_ip

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-aws
+++ b/archive/puphpet/vagrant/Vagrantfile-aws
@@ -10,6 +10,8 @@ Vagrant.configure('2') do |config|
     aws.keypair_name              = "#{data['vm']['provider']['aws']['keypair_name']}"
     aws.ami                       = "#{data['vm']['provider']['aws']['ami']}"
     aws.instance_type             = "#{data['vm']['provider']['aws']['instance_type']}"
+    aws.subnet_id                 = "#{data['vm']['provider']['aws']['subnet_id']}"
+    aws.elastic_ip                = "#{data['vm']['provider']['aws']['elastic_ip']}"
     override.ssh.username         = "#{data['ssh']['username']}"
     override.ssh.private_key_path = "#{data['ssh']['private_key_path']}"
     if !data['vm']['provider']['aws']['region'].nil?

--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-aws/data.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-aws/data.yml
@@ -15,6 +15,8 @@ vm:
             region: ~
             instance_type: ~
             security_groups: {}
+            subnet_id: ~
+            elastic_ip: ~
             tags:
                 Source: Puphpet
     provision:

--- a/src/Puphpet/MainBundle/Resources/views/vagrantfile-aws/form.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/vagrantfile-aws/form.html.twig
@@ -174,6 +174,33 @@
             </select>
         </div>
 
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                The subnet to boot the instance into, for VPC.
+                <a href="https://console.aws.amazon.com/vpc/home?#subnets:" target="_blank">Get them here</a>.
+            </div>
+            <label for="vagrantfile-vm-provider-aws-subnet_id">VPC Subnet ID</label>
+            <input type="text" id="vagrantfile-vm-provider-aws-subnet_id"
+                   name="vagrantfile[vm][provider][aws][subnet_id]"
+                   class="form-control" placeholder="VPC Subnet ID"
+                   value="{{ data.vm.provider.aws.subnet_id }}" />
+        </div>
+
+        <div class="clearfix"></div>
+
+        <div class="form-group col-xs-6">
+            <div class="help-text">
+                Assign an elastic IP address to this instance.
+                <a href="https://console.aws.amazon.com/ec2/v2/home?Addresses#Addresses:sort=publicIp" target="_blank">Get them here</a>.
+            </div>
+            <label for="vagrantfile-vm-provider-aws-elastic_ip">Elastic IP Address</label>
+            <input type="text" id="vagrantfile-vm-provider-aws-elastic_ip"
+                   name="vagrantfile[vm][provider][aws][elastic_ip]"
+                   class="form-control" placeholder="Elastic IP"
+                   value="{{ data.vm.provider.aws.elastic_ip }}" />
+        </div>
+
+
         <div class="clearfix"></div>
 
         {% if providerChosen %}


### PR DESCRIPTION
This commit adds the AWS subnet_id and elastic_ip options to those already supported by Puphpet.  This pull request fixes #1752.

These options are documented in the vagrant-aws README at https://github.com/mitchellh/vagrant-aws.