### PR TITLE
Set Amazon Web Services (AWS) tags.  Resolves #1785

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-aws
+++ b/archive/puphpet/vagrant/Vagrantfile-aws
@@ -22,7 +22,7 @@ Vagrant.configure('2') do |config|
 
     aws.tags = {}
     data['vm']['provider']['aws']['tags'].each do |key, tag|
-      aws.tags.store(:key, :tag)
+      aws.tags.store(key, tag)
     end
   end
 


### PR DESCRIPTION
AWS tags were not being set due to a bug in Vagrantfile-aws.  This fix allows an arbitrary number of tags to be added in config.yaml.  Each of those tags will be added to the instance at 'vagrant up'.

Details on Vagrant's aws.tags support can be found at https://github.com/mitchellh/vagrant-aws

This pull request closes #1785.