### PR TITLE
Text on solr config page

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/solr/form.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/solr/form.html.twig
@@ -25,7 +25,7 @@
                     <span class="title">Install Solr</span>
                 </span>
                 <span class="footer">
-                    The world's most popular open source database.
+                    Solr powers the search and navigation features of many of the world's largest internet sites.
                 </span>
             </span>
         </label>
@@ -52,7 +52,7 @@
             <div class="help-text">
                 Minimum port number is <code>1000</code>.
             </div>
-            <label for="solr-settings-port">Root Password</label>
+            <label for="solr-settings-port">Solr Port</label>
             <input type="number" id="solr-settings-port"
                    name="solr[settings][port]"
                    placeholder="8984" class="form-control"


### PR DESCRIPTION
Fix some text on the solr configuration page that referred to MySQL instead of Solr.