### PR TITLE
Turned off "insert_key" in Vagrantfile-local

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -270,6 +270,10 @@ Vagrant.configure('2') do |config|
   vagrantKey = "#{vagrant_dot}/machines/default/#{ENV['VAGRANT_DEFAULT_PROVIDER']}/private_key"
 
   if File.file?(customKey)
+    # TODO: Improve SSH key insertion
+    # Turn off insert key to prevent failure to login to VM
+    config.ssh.insert_key = false
+
     config.ssh.private_key_path = [
       customKey,
       "#{vagrant_home}/insecure_private_key"


### PR DESCRIPTION
I've turned off the insert key functionality due to the latest version of Vagrant (1.7.4) and maybe earlier, will delete the insecure_private_key's public key from the VM if it's detected and generate a new private key. Since this overwrites the generated private key, the public key that was inserted into the VM is no longer valid preventing Vagrant from being able to login via SSH.

The changes don't seem to be recent, so I'm unsure why this has become a problem now, but for some reason if I have a custom SSH key set, Vagrant is unable to access the VM at ```vagrant up```.

Reference: https://github.com/mitchellh/vagrant/blob/master/plugins/communicators/ssh/communicator.rb#L157-L187