### PR TITLE
Add dependency from Python packages to install PIP

### DIFF
--- a/archive/puphpet/puppet/nodes/Python.pp
+++ b/archive/puphpet/puppet/nodes/Python.pp
@@ -3,6 +3,7 @@ class puphpet_python (
 ) {
 
   include pyenv::params
+  require supervisord::pip
 
   puphpet::python::preinstall { 'foo':
     before => Class['pyenv'],


### PR DESCRIPTION
Python packages are installed via the pip command installed by the puphpet supervisord::pip puppet module. This ensures that pip is installed prior to installing a Python package (via pip).

This pull request addresses issue https://github.com/puphpet/puphpet/issues/1518 that I requested be reopened (in issue https://github.com/puphpet/puphpet/issues/1808 )

@jtreminio, you probably want to review this, since you closed https://github.com/puphpet/puphpet/issues/1518