### PR TITLE
Adding support for nginx internal location -- #1820

### DIFF
--- a/archive/puphpet/puppet/nodes/Nginx.pp
+++ b/archive/puphpet/puppet/nodes/Nginx.pp
@@ -134,6 +134,7 @@ class puphpet_nginx (
           {
             'location'              => '/',
             'autoindex'             => 'off',
+            'internal'              => false,
             'try_files'             => ['$uri', '$uri/', 'index.php',],
             'fastcgi'               => '',
             'fastcgi_index'         => '',
@@ -144,6 +145,7 @@ class puphpet_nginx (
           {
             'location'              => '~ \.php$',
             'autoindex'             => 'off',
+            'internal'              => false,
             'try_files'             => [
               '$uri', '$uri/', 'index.php', '/index.php$is_args$args'
             ],
@@ -266,6 +268,12 @@ class puphpet_nginx (
         $autoindex = 'on'
       } else {
         $autoindex = 'off'
+      }
+
+      if $location['internal'] {
+        $internal = true
+      } else {
+        $internal = false
       }
 
       # remove empty values

--- a/src/Puphpet/MainBundle/Resources/config/nginx/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/nginx/available.yml
@@ -31,6 +31,7 @@ empty_vhost:
 empty_location:
     location: '/'
     autoindex: 0
+    internal: false
     try_files: []
     fastcgi: ~
     fastcgi_index: ~

--- a/src/Puphpet/MainBundle/Resources/config/nginx/defaults.yml
+++ b/src/Puphpet/MainBundle/Resources/config/nginx/defaults.yml
@@ -33,6 +33,7 @@ vhosts:
             -
                 location: '/'
                 autoindex: 0
+                internal: false
                 try_files:
                     - '$uri'
                     - '$uri/'
@@ -44,6 +45,7 @@ vhosts:
             -
                 location: '~ \.php$'
                 autoindex: 0
+                internal: false
                 try_files:
                     - '$uri'
                     - '$uri/'

--- a/src/Puphpet/MainBundle/Resources/views/nginx/sections/location.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/nginx/sections/location.html.twig
@@ -1,5 +1,6 @@
 {% set uniqid = uniqid('nxvl_', true) %}
 {% set autoindex = (location.autoindex is defined and location.autoindex is sameas('on')) ? true : false %}
+{% set internal = (location.internal is defined and location.internal is sameas('on')) ? true : false %}
 {% set try_files = (location.try_files is defined) ? location.try_files : [] %}
 {% set fast_cgi_params_extras = (location.fast_cgi_params_extra is defined) ? location.fast_cgi_params_extra : [] %}
 
@@ -21,7 +22,7 @@
                    value="{{ location.location }}"/>
         </div>
 
-        <div class="form-group col-xs-6">
+        <div class="form-group col-xs-3">
             <div class="clearfix"><label>autoindex</label></div>
 
             <label class="radio-tile mini set-width">
@@ -35,6 +36,26 @@
                     <span class="header">
                         <i class="icon"></i>
                         <span class="title">Enable autoindex</span>
+                    </span>
+                </span>
+            </label>
+        </div>
+
+        <div class="form-group col-xs-3">
+            <div class="clearfix"><label>internal</label></div>
+
+            <label class="radio-tile mini set-width">
+                <span class="help-text">
+                    Designates location as internal-only.
+                    See <a href="http://nginx.org/en/docs/http/ngx_http_core_module.html#internal" title="nginx internal location docs">nginx documentation</a> for more details.
+                </span>
+                <input type="hidden" name="nginx[vhosts][{{ vhostId }}][locations][{{ uniqid }}][internal]" value="off" />
+                <input type="checkbox" name="nginx[vhosts][{{ vhostId }}][locations][{{ uniqid }}][internal]"
+                       class="invisible" {% if internal %}checked{% endif %} value="true" />
+                <span class="content">
+                    <span class="header">
+                        <i class="icon"></i>
+                        <span class="title">Enable internal</span>
                     </span>
                 </span>
             </label>


### PR DESCRIPTION
  * Introduced to support recommended Symfony config.
  * Based primarily off of existing autoindex support. Uses boolean flag to [match usage in puppet module](https://github.com/jfryman/puppet-nginx/blob/v0.2.7/manifests/resource/location.pp#L8).
  * See [nginx documentation](http://nginx.org/en/docs/http/ngx_http_core_module.html#internal) for more details