### PR TITLE
Provision hostmanager after configuring it

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -71,6 +71,8 @@ Vagrant.configure('2') do |config|
       config.hostmanager.ignore_private_ip = false
       config.hostmanager.include_offline   = false
       config.hostmanager.aliases           = hosts
+
+      config.vm.provision :hostmanager
     end
   end
 


### PR DESCRIPTION
Since 1.5, hostmanager will not run on it's own. By provisioning it after the config is set up, it will properly run automatically.