### PR TITLE
Name machines by provider type

### DIFF
--- a/archive/Vagrantfile
+++ b/archive/Vagrantfile
@@ -12,6 +12,12 @@ if File.file?("#{dir}/puphpet/config-custom.yaml")
   configValues.deep_merge!(custom)
 end
 
+provider = ENV['VAGRANT_DEFAULT_PROVIDER']
+if File.file?("#{dir}/puphpet/config-#{provider}.yaml")
+  custom = YAML.load_file("#{dir}/puphpet/config-#{provider}.yaml")
+  configValues.deep_merge!(custom)
+end
+
 data = configValues['vagrantfile']
 
 Vagrant.require_version '>= 1.6.0'

--- a/archive/puphpet/puppet/hiera.yaml
+++ b/archive/puphpet/puppet/hiera.yaml
@@ -3,6 +3,7 @@
 :yaml:
     :datadir: '/vagrant/puphpet'
 :hierarchy:
+    - config-%{::provisioner_type}
     - config-custom
     - config
 :merge_behavior: deeper

--- a/archive/puphpet/puppet/site.pp
+++ b/archive/puphpet/puppet/site.pp
@@ -1,7 +1,15 @@
-$yaml = merge_yaml(
+$config = merge_yaml(
   '/vagrant/puphpet/config.yaml',
   '/vagrant/puphpet/config-custom.yaml'
 )
+
+# a little ugly, can be improved if merge_yaml could support 3 args
+$provisionerConfig = merge_yaml(
+  "/vagrant/puphpet/config-${::provisioner_type}.yaml",
+  ""
+)
+
+$yaml = deep_merge($config, $provisionerConfig)
 
 $apache         = $yaml['apache']
 $beanstalkd     = hiera_hash('beanstalkd', {})

--- a/archive/puphpet/vagrant/Vagrantfile-aws
+++ b/archive/puphpet/vagrant/Vagrantfile-aws
@@ -3,6 +3,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'aws'
 
 Vagrant.configure('2') do |config|
+  config.vm.define   :aws
   config.vm.box      = 'dummy'
   config.vm.hostname = "#{data['vm']['hostname']}"
 

--- a/archive/puphpet/vagrant/Vagrantfile-digitalocean
+++ b/archive/puphpet/vagrant/Vagrantfile-digitalocean
@@ -3,6 +3,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'digital_ocean'
 
 Vagrant.configure('2') do |config|
+  config.vm.define   :digital_ocean
   config.vm.box      = 'dummy'
   config.vm.hostname = "#{data['vm']['hostname']}"
   config.nfs.functional = false

--- a/archive/puphpet/vagrant/Vagrantfile-gce
+++ b/archive/puphpet/vagrant/Vagrantfile-gce
@@ -5,6 +5,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'google'
 require 'fog/version'
 
 Vagrant.configure('2') do |config|
+  config.vm.define   :gce
   config.vm.box      = 'gce'
   config.vm.hostname = "#{data['vm']['hostname']}"
 

--- a/archive/puphpet/vagrant/Vagrantfile-ikoulacloud
+++ b/archive/puphpet/vagrant/Vagrantfile-ikoulacloud
@@ -3,6 +3,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'cloudstack'
 
 Vagrant.configure('2') do |config|
+  config.vm.define   :cloudstack
   config.vm.box      = 'dummy'
   config.vm.hostname = "#{data['vm']['hostname']}"
 

--- a/archive/puphpet/vagrant/Vagrantfile-linode
+++ b/archive/puphpet/vagrant/Vagrantfile-linode
@@ -3,6 +3,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'linode'
 
 Vagrant.configure('2') do |config|
+  config.vm.define   :linode
   config.vm.box      = 'dummy'
   config.vm.hostname = "#{data['vm']['hostname']}"
 

--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -4,6 +4,7 @@ vagrant_home = (ENV['VAGRANT_HOME'].to_s.split.join.length > 0) ? ENV['VAGRANT_H
 vagrant_dot  = (ENV['VAGRANT_DOTFILE_PATH'].to_s.split.join.length > 0) ? ENV['VAGRANT_DOTFILE_PATH'] : "#{dir}/.vagrant"
 
 Vagrant.configure('2') do |config|
+  config.vm.define  :local
   config.vm.box     = "#{data['vm']['box']}"
   config.vm.box_url = "#{data['vm']['box_url']}"
 

--- a/archive/puphpet/vagrant/Vagrantfile-rackspace
+++ b/archive/puphpet/vagrant/Vagrantfile-rackspace
@@ -5,6 +5,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'rackspace'
 require 'fog/version'
 
 Vagrant.configure('2') do |config|
+  config.vm.define      :rackspace
   config.vm.box         = 'dummy'
   config.vm.hostname    = "#{data['vm']['hostname']}"
   config.nfs.functional = false

--- a/archive/puphpet/vagrant/Vagrantfile-softlayer
+++ b/archive/puphpet/vagrant/Vagrantfile-softlayer
@@ -3,6 +3,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'softlayer'
 
 Vagrant.configure('2') do |config|
+  config.vm.define            :softlayer
   config.nfs.functional       = false
   config.ssh.username         = 'root'
   config.ssh.private_key_path = "#{data['ssh']['private_key_path']}"


### PR DESCRIPTION
This change allowed me to have multiple different providers under the same vagrant directory. 

So this way, I can have "rackspace" and a "local" machine both can be accessed via the vagrant cli commands (also with some VAGRANT_DEFAULT_PROVIDER ENV variable tweaking). I also managed to have different config yaml files for each provider this way! So we can do config-rackspace.yaml, config-virtualbox.yaml, etc. using the environment variable.

Could be a good first step towards https://github.com/puphpet/puphpet/issues/367