### PR TITLE
Alternative fix problem for MariaDB /tmp folder. Resolves #1839 and #1805

### DIFF
--- a/archive/puphpet/puppet/nodes/MariaDb.pp
+++ b/archive/puphpet/puppet/nodes/MariaDb.pp
@@ -75,7 +75,9 @@ class puphpet_mariadb (
   }
 
   # prevent problems with being unable to create dir in /tmp
-  if ! defined(File[$override_options['mysqld']['tmpdir']]) {
+  if ! defined(File[$override_options['mysqld']['tmpdir']]) 
+    and File[$override_options['mysqld']['tmpdir'] != '/tmp'
+  {
     file { $override_options['mysqld']['tmpdir']:
       ensure  => directory,
       owner   => $mariadb_user,


### PR DESCRIPTION
As mentioned in #1805, MariaDB install will overwrite the permissions for the /tmp directory, making it so only the mysql user can use it. This is obviously an unexpected behavior and should be fixed. I'm unsure whether this should just check if the tmpdir is not /tmp or remove this check completely.

Choose whichever is appropriate, this or #1926.