### PR TITLE
Google Compute Engine updates: VMs, images, and zones

### DIFF
--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
@@ -74,6 +74,9 @@ zones:
     europe-west1-b: europe-west1-b
     europe-west1-c: europe-west1-c
     europe-west1-d: europe-west1-d
+    us-east1-b: us-east1-b
+    us-east1-c: us-east1-c
+    us-east1-d: us-east1-d
     us-central1-a: us-central1-a
     us-central1-b: us-central1-b
     us-central1-c: us-central1-c

--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
@@ -1,6 +1,14 @@
 images:
     -
-        image: debian-7-wheezy-v20150603
+        image: debian-8-jessie-v20150915
+        long_name: Debian Jessie 8 x64
+        php_versions:
+            - 5.6
+            - 5.5
+            - 5.4
+            - HHVM
+    -
+        image: debian-7-wheezy-v20150915
         long_name: Debian Wheezy 7 x64
         php_versions:
             - 5.6
@@ -8,7 +16,23 @@ images:
             - 5.4
             - HHVM
     -
-        image: ubuntu-1404-trusty-v20150316
+        image: ubuntu-1504-vivid-v20150911
+        long_name: Ubuntu Vivid 15.04 x64
+        php_versions:
+            - 7.0
+            - 5.6
+            - 5.5
+            - HHVM
+    -
+        image: ubuntu-1410-utopic-v20150625
+        long_name: Ubuntu Utopic 14.10 x64
+        php_versions:
+            - 7.0
+            - 5.6
+            - 5.5
+            - HHVM
+    -
+        image: ubuntu-1404-trusty-v20150909a
         long_name: Ubuntu Trusty 14.04 LTS x64
         php_versions:
             - 7.0
@@ -16,7 +40,7 @@ images:
             - 5.5
             - HHVM
     -
-        image: ubuntu-1204-precise-v20150616
+        image: ubuntu-1204-precise-v20150910
         long_name: Ubuntu Precise 12.04 LTS x64
         php_versions:
             - 5.5

--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/available.yml
@@ -55,17 +55,17 @@ machine_types:
     n1-standard-4: 4 vCPU, 15 GB memory
     n1-standard-8: 8 vCPU, 30 GB memory
     n1-standard-16: 16 vCPU, 60 GB memory
-    n1-standard-32: 32 vCPU, 120 GB memory (beta)
+    n1-standard-32: 32 vCPU, 120 GB memory
     n1-highmem-2: 2 vCPU, 13 GB memory
     n1-highmem-4: 4 vCPU, 26 GB memory
     n1-highmem-8: 8 vCPU, 52 GB memory
     n1-highmem-16: 16 vCPU, 104 GB memory
-    n1-highmem-32: 32 vCPU, 208 GB memory (beta)
+    n1-highmem-32: 32 vCPU, 208 GB memory
     n1-highcpu-2: 2 vCPU, 1.8 GB memory
     n1-highcpu-4: 4 vCPU, 3.6 GB memory
     n1-highcpu-8: 8 vCPU, 7.2 GB memory
     n1-highcpu-16: 16 vCPU, 14.4 GB memory
-    n1-highcpu-32: 32 vCPU, 28.8 GB memory (beta)
+    n1-highcpu-32: 32 vCPU, 28.8 GB memory
 
 zones:
     asia-east1-a: asia-east1-a

--- a/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/defaults.yml
+++ b/src/Puphpet/MainBundle/Resources/config/vagrantfile-gce/defaults.yml
@@ -7,7 +7,7 @@ vm:
             client_email: GCE_CLIENT_EMAIL
             key_location: /PATH/TO/PRIVATE_KEY.PK12
             machine_type: n1-standard-1
-            image: ubuntu-1404-trusty-v20141212
+            image: ubuntu-1504-vivid-v20150911
             name: instance-name
             zone: us-central1-a
             tags:


### PR DESCRIPTION
I have updated the following:

* added Debian 8, Ubuntu Utopic, and Ubuntu Vivid images; updated other images to the latest version
* marked 32-core VMs as GA
* added newly-launched `us-east1` region
* updated default image to be the latest Ubuntu Vivid image

What I am not clear on:

* What are the appropriate PHP versions for each of the Debian and Ubuntu images?
* Does PuPHPet support other operating systems besides Debian and Ubuntu? I can add other OS images as options (RedHat, CentOS, SUSE, OpenSUSE, etc.) if they can be used.