### PR TITLE
Fixed chmod issues for NFS folders 

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -90,7 +90,7 @@ Vagrant.configure('2') do |config|
           config.vm.synced_folder "#{folder['source']}", "/mnt/vagrant-#{i}", id: "#{i}", type: 'nfs'
           config.bindfs.bind_folder "/mnt/vagrant-#{i}", "#{folder['target']}", owner: sync_owner, group: sync_group, perms: "u=rwX:g=rwX:o=rD"
         else
-          config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs'
+          config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs', :nfs => { :mount_options => ["dmode=777","fmode=666"] }
         end
       elsif folder['sync_type'] == 'smb'
         smb__host     = !folder['smb']['smb_host'].nil? ? folder['smb']['smb_host'] : nil


### PR DESCRIPTION
When using NFS folders, some rights issues can occur (chmod not allowed, …).

This patch fixes it (related to #1756 and probably #1953)