### PR TITLE
Fix requiring redis pecl extension on PHP 7

### DIFF
--- a/archive/puphpet/puppet/manifests/Redis.pp
+++ b/archive/puphpet/puppet/manifests/Redis.pp
@@ -14,14 +14,14 @@ class puphpet_redis (
   create_resources('class', { 'redis' => $redis['settings'] })
 
   if array_true($php, 'install') and ! defined(Puphpet::Php::Pecl['redis']) {
-    puphpet::php::pecl { 'redis':
-      service_autorestart => $webserver_restart,
-      require             => Class['redis']
-    }
-
     if $::osfamily == 'debian'
       and $puphpet::php::settings::version in ['54', '5.4']
     {
+      puphpet::php::pecl { 'redis':
+        service_autorestart => $webserver_restart,
+        require             => Class['redis']
+      }
+
       puphpet::php::ini { 'REDIS/extension':
         entry       => "REDIS/extension",
         value       => 'redis.so',


### PR DESCRIPTION
Additionally to PR https://github.com/puphpet/puppet-puphpet/pull/31 this change is required to fix https://github.com/puphpet/puphpet/issues/2056 .

It will disable the pecl installation of the redis extension in other than php 5.4. (It might affect PHP 5.5 and 5.6 but this cases were not tested)