### PR TITLE
fix undefined $php_modules var

### DIFF
--- a/archive/puphpet/puppet/manifests/Php.pp
+++ b/archive/puphpet/puppet/manifests/Php.pp
@@ -97,6 +97,7 @@ class puphpet_php (
     }
   }
 
+  $php_modules = $php['modules']['php'];
   each( $php_modules ) |$name| {
     if ! defined(Puphpet::Php::Module[$name]) {
       puphpet::php::module { $name:


### PR DESCRIPTION
Hi Folks,

$php_modules is undefined since a recent commit (https://github.com/puphpet/puphpet/commit/153d67523857a88fa2681762c0a8aee10f11a1d4#diff-ac31f54b23acb22142b280f0b8cfc172) causing this error 

`Error: Evaluation Error: Error while evaluating a Function Call, each(): wrong argument type (NilClass; must be something enumerable. at /tmp/vagrant-puppet/manifests-75f35e3bc7e32744860c4bb229c88812/Php.pp:100:3`

Just setted the var again.

Resolve : https://github.com/puphpet/puphpet/issues/2142

Thank you :smile: 