### PR TITLE
Enable use under older PHP versions

### DIFF
--- a/src/Puphpet/MainBundle/Extension/Archive.php
+++ b/src/Puphpet/MainBundle/Extension/Archive.php
@@ -4,7 +4,7 @@ namespace Puphpet\MainBundle\Extension;
 
 class Archive
 {
-    const ARCHIVE_LOCATION = __DIR__ . '/../../../../archive';
+    const ARCHIVE_LOCATION = '/../../../../archive';
     const ZIP_COMMAND      = 'cd "%s" && cd .. && zip -r "%s" "%s" -x "*/.git/*" -x "*/.tmp/*" -x "*/.librarian/*"';
 
     /**
@@ -37,7 +37,7 @@ class Archive
     public function getSourceDir()
     {
         if (!$this->sourceDir) {
-            $this->sourceDir = sprintf('%s/%s', self::ARCHIVE_LOCATION, $this->subDir);
+            $this->sourceDir = sprintf('%s/%s', __DIR__.self::ARCHIVE_LOCATION, $this->subDir);
         }
 
         return $this->sourceDir;

--- a/src/Puphpet/MainBundle/Extension/Manager.php
+++ b/src/Puphpet/MainBundle/Extension/Manager.php
@@ -17,9 +17,9 @@ class Manager
     /** @var array */
     protected $extensions = [];
 
-    public function __construct($confDir = __DIR__ . '/../Resources/config')
+    public function __construct($confDir = false)
     {
-        $this->confDir = $confDir;
+        $this->confDir = ($confDir?$confDir:__DIR__ . '/../Resources/config');
     }
 
     /**


### PR DESCRIPTION
Both changes make the code less elegant, but work for versions of PHP <
5.6. This addresses issue #2176.