### PR TITLE
Force hkp://pgp.mit.edu on port 80.

### DIFF
--- a/archive/puphpet/puppet/manifests/Ruby.pp
+++ b/archive/puphpet/puppet/manifests/Ruby.pp
@@ -9,7 +9,7 @@ class puphpet_ruby (
   -> Puphpet::Ruby::Install <| |>
 
   class { '::rvm':
-    key_server => 'hkp://pgp.mit.edu/',
+    key_server => 'hkp://pgp.mit.edu:80',
   }
 
   if ! defined(Group['rvm']) {


### PR DESCRIPTION
Some may experience this error when provisioning a VM (see issue #2134):

`Error: Key D39DC0E3 does not exist on hkp://pgp.mit.edu/`

This change will force `gpg` to use port 80 when querying the `pgp.mit.edu` key server. 