### PR TITLE
Add missing HTML5 port number validation

### DIFF
--- a/src/Puphpet/MainBundle/Resources/views/vagrantfile-local/sections/machine-forwarded-port.html.twig
+++ b/src/Puphpet/MainBundle/Resources/views/vagrantfile-local/sections/machine-forwarded-port.html.twig
@@ -15,7 +15,7 @@
             <label for="vagrantfile-vm-provider-local-machines-{{ mId }}-network-forwarded_port-{{ uniqid }}-host">Host Port</label>
             <input type="number" id="vagrantfile-vm-provider-local-machines-{{ mId }}-network-forwarded_port-{{ uniqid }}-host"
                    name="vagrantfile[vm][provider][local][machines][{{ mId }}][network][forwarded_port][{{ uniqid }}][host]"
-                   placeholder="8080" class="form-control"
+                   placeholder="8080" min="1" max="65535" class="form-control"
                    value="{{ forwarded_port.host ? forwarded_port.host : mt_rand(5000, 9999) }}" />
         </div>
 
@@ -29,7 +29,7 @@
             <label for="vagrantfile-vm-provider-local-machines-{{ mId }}-network-forwarded_port-{{ uniqid }}-guest">VM Port</label>
             <input type="number" id="vagrantfile-vm-provider-local-machines-{{ mId }}-network-forwarded_port-{{ uniqid }}-guest"
                    name="vagrantfile[vm][provider][local][machines][{{ mId }}][network][forwarded_port][{{ uniqid }}][guest]"
-                   placeholder="80" class="form-control"
+                   placeholder="80" min="1" max="65535" class="form-control"
                    value="{{ forwarded_port.guest ? forwarded_port.guest : '22' }}" />
         </div>
 


### PR DESCRIPTION
When you choose custom port number, it's available to choose unallowed port number (eg. 80111) as a mistake. This change should prevent that.