### PR TITLE
Fix Elasticsearch RPM naming

### DIFF
--- a/archive/puphpet/puppet/manifests/ElasticSearch.pp
+++ b/archive/puphpet/puppet/manifests/ElasticSearch.pp
@@ -16,7 +16,14 @@ class puphpet_elasticsearch (
       $url = "${url_base}/elasticsearch-${version}.deb"
     }
     'redhat': {
-      $url = "${url_base}/elasticsearch-${version}.noarch.rpm"
+      $noarch_rpm = ''
+
+      # Versions less than 2.0.0 have .noarch on the rpm
+      if $version =~ /^1\./ {
+        $noarch_rpm = '.noarch'
+      }
+
+      $url = "${url_base}/elasticsearch-${version}${noarch_rpm}.rpm"
     }
     default: {
       fail('Unrecognized operating system for Elastic Search')


### PR DESCRIPTION
Elasticsearch doesn't include ".noarch" in the RPM file name if the version is greater than 2.0.0.