### PR TITLE
Fix current Build Status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 # PHPUnit tests only, rake spec could not be done within the same travis worker
 # (ruby is installed on a PHP worker but .gemfile will be ignored)
 script:
-  - php ./vendor/phpunit/phpunit/phpunit.php --coverage-text --configuration phpunit_ci.xml.dist
+  - phpunit --coverage-text --configuration phpunit_ci.xml.dist
 
 notifications:
   email:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,10 +13,10 @@
     stopOnIncomplete="false"
     stopOnSkipped="false"
     syntaxCheck="false"
-    bootstrap="./src/Puphpet/MainBundle/Tests/bootstrap.php">
+    bootstrap="./src/PuphpetBundle/Tests/bootstrap.php">
     <testsuites>
         <testsuite name="Application Test Suite">
-            <directory>./src/Puphpet/MainBundle/Tests/Unit/</directory>
+            <directory>./src/PuphpetBundle/Tests/Unit/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit_ci.xml.dist
+++ b/phpunit_ci.xml.dist
@@ -11,10 +11,10 @@
     stopOnIncomplete="false"
     stopOnSkipped="false"
     syntaxCheck="false"
-    bootstrap="./src/Puphpet/MainBundle/Tests/bootstrap.php">
+    bootstrap="./src/PuphpetBundle/Tests/bootstrap.php">
     <testsuites>
         <testsuite name="Application Test Suite">
-            <directory>./src/Puphpet/MainBundle/Tests/Unit/</directory>
+            <directory>./src/PuphpetBundle/Tests/Unit/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/PuphpetBundle/Tests/Unit/BaseTest.php
+++ b/src/PuphpetBundle/Tests/Unit/BaseTest.php
@@ -5,7 +5,7 @@ namespace Puphpet\Tests\Unit;
 use AppKernel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-require_once __DIR__ . '/../../../../../app/AppKernel.php';
+require_once __DIR__ . '/../../../../app/AppKernel.php';
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
@@ -90,5 +90,10 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
 
         return $method->invokeArgs($object, $parameters);
+    }
+
+    public function testKernelShutdown()
+    {
+        $this->SetUp();
     }
 }

--- a/src/PuphpetBundle/Tests/Unit/Extension/ArchiveTest.php
+++ b/src/PuphpetBundle/Tests/Unit/Extension/ArchiveTest.php
@@ -14,9 +14,15 @@ class ArchiveTest extends Unit\BaseTest
 
     public function setUp()
     {
-        $this->archive = $this->getMockBuilder(Archive::class)
+        $this->mock_archive = $this->getMockBuilder(Archive::class)
             ->setMethods(['exec', 'unlink', 'file_put_contents'])
             ->getMock();
+        $this->archive = new Archive;
+    }
+
+    public function testgetSourceDir()
+    {
+        $this->assertFileExists($this->archive->getSourceDir());
     }
 
     public function testQueueToFileReturnsFalseOnNoEmptyFilename()
@@ -61,6 +67,16 @@ class ArchiveTest extends Unit\BaseTest
         $this->assertEquals($expectedArrayCount, count($this->archive->getFilesToWrite()));
     }
 
+    public function testQueueToFileDoesntStoreEmptyFileData()
+    {
+        $emptyfile = [
+            'name'    => '',
+            'content' => NULL
+        ];
+
+        $this->assertFalse($this->archive->queueToFile($emptyfile['name'], $emptyfile['content']));
+    }
+
     public function testWriteCalledFilePutContentsCorrectNumberOfTimes()
     {
         $file1 = [
@@ -76,14 +92,14 @@ class ArchiveTest extends Unit\BaseTest
             'content' => 'file3 content'
         ];
 
-        $this->archive->expects($this->exactly(3))
+        $this->mock_archive->expects($this->exactly(3))
             ->method('file_put_contents');
 
-        $this->archive->queueToFile($file1['name'], $file1['content']);
-        $this->archive->queueToFile($file2['name'], $file2['content']);
-        $this->archive->queueToFile($file3['name'], $file3['content']);
+        $this->mock_archive->queueToFile($file1['name'], $file1['content']);
+        $this->mock_archive->queueToFile($file2['name'], $file2['content']);
+        $this->mock_archive->queueToFile($file3['name'], $file3['content']);
 
-        $this->archive->write();
+        $this->mock_archive->write();
     }
 
     public function testZipReturnsAZipFileLocation()
@@ -101,16 +117,16 @@ class ArchiveTest extends Unit\BaseTest
             'content' => 'file3 content'
         ];
 
-        $this->archive->expects($this->exactly(3))
+        $this->mock_archive->expects($this->exactly(3))
             ->method('file_put_contents');
 
-        $this->archive->expects($this->once())
+        $this->mock_archive->expects($this->once())
             ->method('exec');
 
         $targetDir = '/tmp/foobar';
         $baseDir = 'foobar';
 
-        $this->setAttribute($this->archive, 'targetDir', $targetDir);
+        $this->setAttribute($this->mock_archive, 'targetDir', $targetDir);
 
         $exec = sprintf(
             Archive::ZIP_COMMAND,
@@ -119,17 +135,17 @@ class ArchiveTest extends Unit\BaseTest
             $baseDir
         );
 
-        $this->archive->expects($this->once())
+        $this->mock_archive->expects($this->once())
             ->method('exec')
             ->with($exec);
 
-        $this->archive->queueToFile($file1['name'], $file1['content']);
-        $this->archive->queueToFile($file2['name'], $file2['content']);
-        $this->archive->queueToFile($file3['name'], $file3['content']);
+        $this->mock_archive->queueToFile($file1['name'], $file1['content']);
+        $this->mock_archive->queueToFile($file2['name'], $file2['content']);
+        $this->mock_archive->queueToFile($file3['name'], $file3['content']);
 
-        $this->archive->write();
+        $this->mock_archive->write();
 
-        $returned = $this->archive->zip();
+        $returned = $this->mock_archive->zip();
 
         $this->assertEquals($targetDir . '.zip', $returned);
     }

--- a/src/PuphpetBundle/Tests/Unit/Extension/ManagerTest.php
+++ b/src/PuphpetBundle/Tests/Unit/Extension/ManagerTest.php
@@ -135,6 +135,8 @@ class ManagerTest extends Unit\BaseTest
 
         $this->assertEquals($extOneData['defaults'], $extensionValues['defaults']);
         $this->assertEquals($extOneData['data'], $extensionValues['data']);
+        $this->assertEquals($extOneData['data'], $manager->getExtensionData('vagrantfile-local'));
+        $this->assertEquals($extOneData['available'], $manager->getExtensionAvailableData('vagrantfile-local'));
     }
 
     public function testAddExtensionMergesDataDefaultsAndAvailableData()
@@ -172,11 +174,11 @@ class ManagerTest extends Unit\BaseTest
         $manager->addExtension('vagrantfile-local');
         $manager->addExtension('vagrantfile-rackspace');
 
-        $customData = Yaml::parse(self::CONF_DIR . '/custom-data/custom.yml');
+        $customData = Yaml::parse(file_get_contents(self::CONF_DIR . '/custom-data/custom.yml'));
 
         $manager->setCustomDataAll($customData);
 
-        $expectedResult = Yaml::parse(self::CONF_DIR . '/custom-data/expected-merged.yml');
+        $expectedResult = Yaml::parse(file_get_contents(self::CONF_DIR . '/custom-data/expected-merged.yml'));
 
         $this->assertEquals($expectedResult, $manager->getExtensions());
     }

--- a/src/PuphpetBundle/Tests/Unit/ReflectionTest.php
+++ b/src/PuphpetBundle/Tests/Unit/ReflectionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PuphpetBundle\Extension;
+
+use Puphpet\Tests\Unit\BaseTest;
+use PuphpetBundle\Extension\Archive;
+use PuphpetBundle\Twig\BaseExtension;
+
+use RandomLib\Factory;
+
+function error_log($msg)
+{
+    // this will be called instead of the native error_log() function
+    echo "ERR: $msg";
+}
+
+class ReflectionTest extends BaseTest
+{
+
+    public function testArchiveExecFakeCMD()
+    {
+        $fakecmd = 'helloworld';
+
+        $this->expectOutputString('ERR: Command not found: ' . $fakecmd);
+        $this->assertEquals('', $this->invokeMethod(new Archive, 'exec', array($fakecmd)));
+    }
+
+    public function testGetAttribute()
+    {
+        $randomLib = new \RandomLib\Factory;
+        $_randomLib = $this->getAttribute(new BaseExtension($randomLib), 'randomLib');
+        $this->assertEquals($randomLib, $_randomLib);
+    }
+
+}

--- a/src/PuphpetBundle/Tests/bootstrap.php
+++ b/src/PuphpetBundle/Tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require __DIR__ . '/../../../../vendor/autoload.php';
+$loader = require __DIR__ . '/../../../vendor/autoload.php';
 $loader->add('PuphpetBundle\Tests\Unit', __DIR__ . '/Unit');
 
 error_reporting(E_ALL);


### PR DESCRIPTION
Update paths used for PHPUnit and fix unit tests
 - Yaml::parse now requires file contents instead of filepath
 - Add / update tests to get closer to 100% coverage