### PR TITLE
Fix samba shares not working with default (empty) configuration.

### DIFF
--- a/src/PuphpetBundle/Extension/Manager.php
+++ b/src/PuphpetBundle/Extension/Manager.php
@@ -101,6 +101,15 @@ class Manager
      */
     public function createArchive(array $data)
     {
+        /*
+         * Replace empty strings with nulls, so they are dumped to yaml correctly
+         */
+        array_walk_recursive($data, function (&$submittedValue) {
+            if ($submittedValue === '') {
+                $submittedValue = null;
+            }
+        });
+
         foreach ($data as $key => $values) {
             $name = $this->parseDataKeyName($values, $key);
 


### PR DESCRIPTION
Fixes: #2152 #2144 

The problem was related with the fact, that empty strings were being assigned to `smb_host`, `smb_username` and `smb_password`. This in turn:

1. Was disabling vagrant's samba config auto-detection feature.
2. Was actually making vagrant use empty string as the hostname, username and password for samba, which was failing with a very obscure error during machine's sync folders mounting procedure
```
mount.cifs: bad UNC (///ca0b69ca37b6771e803d9671c6226dd4)
```
The triple forward slashes show, that the hostname was empty (normally, it would say: `//hostname/ca0b69ca37b6771e803d9671c6226dd4` or something like that)

The fix is actually doing more. It's ensuring that every empty string submitted by the wizard, ends up as `null` in `config.yaml`. This is a very brave change, but I think it's worth it. I fully provisioned a machine with this change without problems, if that means anything. The down side is, that the php's nulls end up as the keyword `null` in the `config.yaml` instead of `~`. I.e. it looks uglier now. But I don't think anyone would complain about that.