### PR TITLE
Use nodesource.com/setup to install nodejs on any of both OS families

### DIFF
--- a/archive/puphpet/puppet/manifests/NodeJs.pp
+++ b/archive/puphpet/puppet/manifests/NodeJs.pp
@@ -13,71 +13,37 @@ class puphpet_nodejs (
   if $::osfamily == 'debian' {
     if ! defined('apt-transport-https') {
       package { 'apt-transport-https':
-        ensure => present
+        ensure => present,
+        before => Exec['add nodejs repo']
       }
     }
+  }
 
-    $version = $version_num ? {
-      '5'     => '5.x',
-      '4'     => '4.x',
-      '0.12'  => '0.12',
-      '0.10'  => '0.10',
-      default => "${version_num}.x"
-    }
+  $provider = $::osfamily ? {
+    'debian' => 'deb',
+    default  => 'rpm'
+  }
 
-    $url = "https://deb.nodesource.com/setup_${version}"
+  $version = $version_num ? {
+    '5'     => '5.x',
+    '4'     => '4.x',
+    '0.12'  => '0.12',
+    '0.10'  => '0.10',
+    default => "${version_num}.x"
+  }
 
-    $save_to = '/.puphpet-stuff/nodesource'
+  $url = "https://${provider}.nodesource.com/setup_${version}"
 
-    exec { 'add nodejs repo':
-      command => "wget --quiet --tries=5 --connect-timeout=10 -O '${save_to}' ${url} \
-                  && bash ${save_to}",
-      creates => $save_to,
-      path    => '/usr/bin:/bin',
-      require => Package['apt-transport-https'],
-    }
-    -> package { 'nodejs':
-      ensure => present,
-    }
-  } else {
-    $pkg_url = $version_num ? {
-      '0.12'  => 'https://rpm.nodesource.com/pub_0.12/el/6/x86_64/nodejs-0.12.9-1nodesource.el6.x86_64.rpm',
-      '0.10'  => 'https://rpm.nodesource.com/pub_0.10/el/6/x86_64/nodejs-0.10.41-1nodesource.el6.x86_64.rpm',
-      default => false
-    }
+  $save_to = '/.puphpet-stuff/nodesource'
 
-    if ! $pkg_url {
-      fail('You have chosen an unsupported NodeJS version.')
-    }
-
-    $dev_url = $version_num ? {
-      '0.12' => 'https://rpm.nodesource.com/pub_0.12/el/6/x86_64/nodejs-devel-0.12.9-1nodesource.el6.x86_64.rpm',
-      '0.10' => 'https://rpm.nodesource.com/pub_0.10/el/6/x86_64/nodejs-devel-0.10.41-1nodesource.el6.x86_64.rpm',
-    }
-
-    $pkg_save_to = '/.puphpet-stuff/nodesource_pkg'
-    $dev_save_to = '/.puphpet-stuff/nodesource_dev'
-
-    exec { 'add nodejs rpm':
-      command => "wget --quiet --tries=5 --connect-timeout=10 -O '${pkg_save_to}' ${pkg_url}",
-      creates => $pkg_save_to,
-      path    => '/usr/bin:/bin',
-    }
-    -> exec { 'add nodejs dev rpm':
-      command => "wget --quiet --tries=5 --connect-timeout=10 -O '${dev_save_to}' ${dev_url}",
-      creates => $dev_save_to,
-      path    => '/usr/bin:/bin',
-    }
-    -> package { 'nodejs':
-      ensure   => 'present',
-      provider => 'rpm',
-      source   => $pkg_save_to,
-    }
-    -> package { 'nodejs-devel':
-      ensure   => 'present',
-      provider => 'rpm',
-      source   => $dev_save_to,
-    }
+  exec { 'add nodejs repo':
+    command => "wget --quiet --tries=5 --connect-timeout=10 -O '${save_to}' ${url} \
+                && bash ${save_to}",
+    creates => $save_to,
+    path    => '/usr/bin:/bin',
+  }
+  -> package { 'nodejs':
+    ensure => present,
   }
 
   each( $nodejs['npm_packages'] ) |$package| {


### PR DESCRIPTION
This allows the RHEL family to install any NodeJS version. Tested with a CentOS 6.5 install without issues.

Basically, it adds the nodesource repo and uses the same setup script as a deb installment would. 