### PR TITLE
Updated deprecated provider switch ‘use_linked_clone’ to ‘linked_clone’.

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -305,7 +305,7 @@ machines.each do |i, machine|
           skipKeys = [
             'memsize',
             'cpus',
-            'use_linked_clone',
+            'linked_clone',
             'check_guest_tools',
             'update_guest_tools'
           ]
@@ -317,9 +317,9 @@ machines.each do |i, machine|
           v.customize ['set', :id, "--#{key}", "#{value}"]
         end
 
-        if !provider['virtualizers']['parallels']['use_linked_clone'].nil? &&
-          provider['virtualizers']['parallels']['use_linked_clone'].to_i == 1
-          v.use_linked_clone = true
+        if !provider['virtualizers']['parallels']['linked_clone'].nil? &&
+          provider['virtualizers']['parallels']['linked_clone'].to_i == 1
+          v.linked_clone = true
         end
 
         if !provider['virtualizers']['parallels']['check_guest_tools'].nil? &&

--- a/src/PuphpetBundle/Resources/config/vagrantfile-local/data.yml
+++ b/src/PuphpetBundle/Resources/config/vagrantfile-local/data.yml
@@ -15,7 +15,7 @@ vm:
                 vmware:
                     numvcpus: 1
                 parallels:
-                    use_linked_clone: 0
+                    linked_clone: 0
                     check_guest_tools: 0
                     update_guest_tools: 0
             machines: []

--- a/src/PuphpetBundle/Resources/config/vagrantfile-local/defaults.yml
+++ b/src/PuphpetBundle/Resources/config/vagrantfile-local/defaults.yml
@@ -15,7 +15,7 @@ vm:
                 vmware:
                     numvcpus: 1
                 parallels:
-                    use_linked_clone: 0
+                    linked_clone: 0
                     check_guest_tools: 0
                     update_guest_tools: 0
             machines:


### PR DESCRIPTION
Fixes error “Parallels provider: Vagrantfile option 'use_linked_clone' is deprecated and will be removed. Please, use 'linked_clone' instead”.