### PR TITLE
removed references to the dead repos for CentOS. This includes repofo…

### DIFF
--- a/archive/puphpet/puppet/manifests/Server.pp
+++ b/archive/puphpet/puppet/manifests/Server.pp
@@ -75,9 +75,6 @@ class puphpet_server (
     'redhat': {
       class { 'yum': extrarepo => ['epel'] }
 
-      class { 'yum::repo::rpmforge': }
-      class { 'yum::repo::repoforgeextras': }
-
       Class['::yum'] -> Yum::Managed_yumrepo <| |> -> Package <| |>
 
       if ! defined(Package['augeas']) {


### PR DESCRIPTION
…rge and rpmforge. This fix needs to be pulled at the same time as https://github.com/puphpet/puppet-yum/pull/3

This fixes https://github.com/puphpet/puphpet/issues/2362