### PR TITLE
Commited by AlexMazaltov alex.mazaltov@gmail.com Issue: Mount shared …

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -176,6 +176,9 @@ machines.each do |i, machine|
           smb__file_options = !folder['smb']['mount_options']['file_mode'].nil? ?
             folder['smb']['mount_options']['file_mode'] :
             0664
+          smb__vers = !folder['smb']['mount_options']['vers'].nil? ?
+            folder['smb']['mount_options']['vers'] :
+            '3.0'
 
           machine_id.vm.synced_folder "#{folder['source']}", "#{folder['target']}",
             id: "#{i}",
@@ -185,7 +188,7 @@ machines.each do |i, machine|
             smb_host: smb__host,
             smb_username: smb__username,
             smb_password: smb__password,
-            mount_options: ["dir_mode=#{smb__dir_options},file_mode=#{smb__file_options}"]
+            mount_options: ["dir_mode=#{smb__dir_options},file_mode=#{smb__file_options},vers=#{smb__vers}"]
         elsif folder['sync_type'] == 'rsync'
           rsync_args    = !folder['rsync']['args'].nil? ?
             folder['rsync']['args'] :


### PR DESCRIPTION
…folders of type smb returns Host is Down message additional mount options implementation have been added [vers=3.0] according to this article https://ask.fedoraproject.org/en/question/87463/samba-windows-10-share-mount-error112-host-is-down/?answer=99818#post-id-99818