### PR TITLE
Correct label and placeholder text

### DIFF
--- a/src/PuphpetBundle/Resources/views/cron/job.html.twig
+++ b/src/PuphpetBundle/Resources/views/cron/job.html.twig
@@ -72,7 +72,7 @@
         </label>
         <input type="text" id="cron-jobs-{{ uniqid }}-minute"
                name="cron[jobs][{{ uniqid }}][minute]"
-               placeholder="echo &quot;you are beautiful&quot;" class="form-control"
+               placeholder="" class="form-control"
                value="{{ job.minute }}" />
         <div class="help-block">
             <code>0-59</code> for a specific minute of the hour,

--- a/src/PuphpetBundle/Resources/views/php.html.twig
+++ b/src/PuphpetBundle/Resources/views/php.html.twig
@@ -343,7 +343,7 @@
                                {% if drush.install %}checked{% endif %}
                                data-toggle="checkbox-collapse"
                                data-target="#drush-container" />
-                        <label for="drush-install">Install WP-CLI</label>
+                        <label for="drush-install">Install Drush</label>
                     </div>
 
                     <div id="drush-container"


### PR DESCRIPTION
PHP addon "Drush" was mislabeled as "WP-CLI".

`echo "you are beautiful"` appeared in both the cron job command field as well as the minute field (which didn't make sense).