### PR TITLE
VMWare Workstation configuration fix - Issue 2437 - Issue 2629

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -306,6 +306,28 @@ machines.each do |i, machine|
           end
         end
       end
+      machine_id.vm.provider :vmware_workstation do |v, override|
+        provider['virtualizers']['vmware'].each do |key, value|
+          if key == 'memsize'
+            next
+          end
+          if key == 'cpus'
+            next
+          end
+
+          v.vmx["#{key}"] = "#{value}"
+        end
+
+        v.vmx['memsize']  = "#{machine['memory']}"
+        v.vmx['numvcpus'] = "#{machine['cpus']}"
+
+        if provider['virtualizers']['vmware']['displayName'].nil? ||
+          provider['virtualizers']['vmware']['displayName'].empty?
+          if machine_id.vm.hostname.to_s.strip.length != 0
+            v.vmx['displayName'] = machine_id.vm.hostname
+          end
+        end
+      end
     end
 
     if chosen_virtualizer == 'parallels'


### PR DESCRIPTION
Fix for Issue [2437](https://github.com/puphpet/puphpet/issues/2437) and [2629](https://github.com/puphpet/puphpet/issues/2629)

The problem is, that `vmware_fusion` and `vmware_workstation` are handled together, as they mostly (always?) have the same settings. However, the settings only get applied to `vmware_fusion`, which leaves the `vmware_workstation` to use the default settings of 1 CPU and 512MB Ram.