### PR TITLE
changed when bindfs binding occurs to fix issue #2642

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -152,7 +152,7 @@ machines.each do |i, machine|
               id: "#{i}",
               type: 'nfs'
             machine_id.bindfs.bind_folder "/mnt/vagrant-#{i}", "#{folder['target']}",
-              after: :provision,
+              after: :synced_folders,
               force_user: sync_owner,
               force_group: sync_group,
               perms: "u=rwX:g=rwX:o=rD",


### PR DESCRIPTION
This change makes binding occur earlier in the provisioning process (as opposed to after it), allowing data in bound directories to be used by the rest of the provisioning operations (such as database imports). 

Change has not cause any regression issues in my local testing.