### PR TITLE
Add full support for vagrant-hostsupdater

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -90,8 +90,7 @@ machines.each do |i, machine|
       end
     end
 
-    # https://github.com/smdahlen/vagrant-hostmanager
-    if Vagrant.has_plugin?('vagrant-hostmanager')
+    if Vagrant.has_plugin?('vagrant-hostmanager') || Vagrant.has_plugin?('vagrant-hostsupdater')
       hosts = Array.new()
 
       if !configValues['hosts'].nil?
@@ -130,7 +129,12 @@ machines.each do |i, machine|
         if machine_id.vm.hostname.to_s.strip.length == 0
           machine_id.vm.hostname = "#{machine['id']}-dev-machine"
         end
+      end
+    end
 
+    # https://github.com/smdahlen/vagrant-hostmanager
+    if Vagrant.has_plugin?('vagrant-hostmanager')
+      if hosts.any?
         machine_id.hostmanager.enabled           = true
         machine_id.hostmanager.manage_host       = true
         machine_id.hostmanager.ignore_private_ip = false
@@ -138,6 +142,13 @@ machines.each do |i, machine|
         machine_id.hostmanager.aliases           = hosts.uniq
 
         machine_id.vm.provision :hostmanager
+      end
+    end
+
+    # https://github.com/cogitatio/vagrant-hostsupdater
+    if Vagrant.has_plugin?('vagrant-hostsupdater')
+      if hosts.any?
+        machine_id.hostsupdater.aliases = hosts.uniq
       end
     end
 


### PR DESCRIPTION
While PuPHPet does support the vagrant-hostmanager plugin, that plugin unfortunately does not remove entries in the _hosts_ file when a machine is suspended. This has been marked as [wontfix](https://github.com/devopsgroup-io/vagrant-hostmanager/issues/143).

The vagrant-hostsupdater plugin supports this functionality. Removal of host entries on suspend has been mentioned before in an [issue](https://github.com/puphpet/puphpet/issues/1484). The biggest advantage: using the same hostnames as the production environment without having to destroy the VM each time you would like to access the production environment.

While vagrant-hostsupdater mostly works out of the box without having to add any config entries, it does not add entries for the different Apache/nginx virtual hosts without additional configuration. This pull request takes care of this.