### PR TITLE
add target=_blank to external links

### DIFF
--- a/src/PuphpetBundle/Resources/views/composer.html.twig
+++ b/src/PuphpetBundle/Resources/views/composer.html.twig
@@ -1,5 +1,5 @@
 <div class="help-block">
-    <a href="https://getcomposer.org">Composer</a> will be available as a
+    <a href="https://getcomposer.org" target="_blank">Composer</a> will be available as a
     system service: <code>$ composer</code>
 </div>
 

--- a/src/PuphpetBundle/Resources/views/hhvm.html.twig
+++ b/src/PuphpetBundle/Resources/views/hhvm.html.twig
@@ -33,7 +33,7 @@
         <div class="form-group col-xs-12">
             <div class="checkbox">
                 <span class="help-text">
-                    <a href="https://getcomposer.org">Composer</a> will be available as a
+                    <a href="https://getcomposer.org" target="_blank">Composer</a> will be available as a
                     system service:<br />
                     <code>$ composer</code>
                 </span>

--- a/src/PuphpetBundle/Resources/views/nginx/location.html.twig
+++ b/src/PuphpetBundle/Resources/views/nginx/location.html.twig
@@ -85,7 +85,7 @@
         <div class="help-block">
             Designates location as internal-only.
             See <a href="http://nginx.org/en/docs/http/ngx_http_core_module.html#internal"
-                   title="nginx internal location docs">nginx documentation</a>
+                   target="_blank" title="nginx internal location docs">nginx documentation</a>
             for more details.
         </div>
     </div>

--- a/src/PuphpetBundle/Resources/views/sqlite.html.twig
+++ b/src/PuphpetBundle/Resources/views/sqlite.html.twig
@@ -27,10 +27,10 @@
                 <p>The preferred way to connect to your database is using a dedicated
                     application like
                     <a href="http://www.valentina-db.com/valentina-studio-overview" target="_blank">Valentina Studio (OS X)</a>,
-                    <a href="http://sqliteman.com/">Sqliteman (Windows/Linux)</a>,
-                    <a href="http://sqliteadmin.orbmu2k.de/">SQLite Administrator (Windows)</a>,
+                    <a href="http://sqliteman.com/" target="_blank">Sqliteman (Windows/Linux)</a>,
+                    <a href="http://sqliteadmin.orbmu2k.de/" target="_blank">SQLite Administrator (Windows)</a>,
                     and
-                    <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">SQLite Manager (FireFox)</a>.</p>
+                    <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/" target="_blank">SQLite Manager (FireFox)</a>.</p>
                 <p>Connect using SSH tunnel, username <code>vagrant</code> and SSH key generated at
                     <code>puphpet/files/dot/ssh/id_rsa</code>. This key is generated <strong>after</strong>
                     your initial <code>$ vagrant up</code>!</p>


### PR DESCRIPTION
Most external links have target="_blank", but some of them are missing it, which causes you to lose your unsaved changes when you click one of them and come back.