### PR TITLE
Add ability to mount bindfs folder after provision

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-local
+++ b/archive/puphpet/vagrant/Vagrantfile-local
@@ -164,7 +164,7 @@ machines.each do |i, machine|
               id: "#{i}",
               type: 'nfs'
             machine_id.bindfs.bind_folder "/mnt/vagrant-#{i}", "#{folder['target']}",
-              after: :synced_folders,
+              after: !folder['after'].nil? ? folder['after'].to_sym : :synced_folders,
               force_user: sync_owner,
               force_group: sync_group,
               perms: "u=rwX:g=rwX:o=rD",


### PR DESCRIPTION
In most cases a local PHP project is mounted into to VM and gets the permission of the webserver to avoid issues with write permissions to cache/build folders.
But the apache/www-data user is created in the provision step.
A newly introduced parameter 'after' [1] let's you decide if the mount is created after the provision step. Without this option you need to perform a `vagrant up`, let the machine provision and perform a `vagrant reload` to properly mount the web project folder.

bindfs error:
```
==> vm2: Cannot create bind mount from '/mnt/vagrant-vflsf_jb5hvrmn60q8' to '/var/www/webpage': User 'www-data' doesn't exist Group 'www-data' doesn't exist
```
[1] https://github.com/gael-ian/vagrant-bindfs#usage