### PR TITLE
fix loading proxy_redirect

### DIFF
--- a/src/PuphpetBundle/Resources/views/nginx/location.html.twig
+++ b/src/PuphpetBundle/Resources/views/nginx/location.html.twig
@@ -233,7 +233,7 @@
         <input type="text" id="{{ idBase }}-proxy_redirect"
                name="{{ nameBase }}[proxy_redirect]"
                placeholder="off" class="form-control"
-               value="{{ location.proxy }}" />
+               value="{{ location.proxy_redirect }}" />
         <div class="help-block">
             <a href="http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect"
                target="_blank">More information</a>.


### PR DESCRIPTION
When loading a config.yaml from browser it puts proxy adress at proxy_redirect. See what proxy_redirect allows: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect