### PR TITLE
Fix SMB error when deploying to AWS

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-aws
+++ b/archive/puphpet/vagrant/Vagrantfile-aws
@@ -10,6 +10,7 @@ machines.each do |i, machine|
     machine_id.vm.box         = 'dummy'
     machine_id.vm.hostname    = "#{machine['hostname']}"
     machine_id.nfs.functional = false
+    machine_id.vm.allowed_synced_folder_types = :rsync
 
     machine_id.vm.provider :aws do |aws, override|
       aws.access_key_id             = "#{provider['access_key_id']}"


### PR DESCRIPTION
On Vagrant >= 2.0 the sync folder type by default is SMB on macOS, so we need to force it to use rsync.

Refs: 
https://github.com/puphpet/puphpet/issues/2764
https://github.com/hashicorp/vagrant/issues/9960
https://github.com/mitchellh/vagrant-aws/issues/365
https://github.com/devopsgroup-io/vagrant-digitalocean/issues/277