### PR TITLE
Use rsync instead of smb for synced folders on DigitalOcean

### DIFF
--- a/archive/puphpet/vagrant/Vagrantfile-digitalocean
+++ b/archive/puphpet/vagrant/Vagrantfile-digitalocean
@@ -6,6 +6,7 @@ provider = data['vm']['provider']['digitalocean']
 machines = !provider['machines'].empty? ? provider['machines'] : { }
 
 machines.each do |i, machine|
+  config.vm.allowed_synced_folder_types = :rsync
   config.vm.define "#{machine['id']}" do |machine_id|
     machine_id.vm.box         = "dummy"
     machine_id.vm.hostname    = "#{machine['hostname']}"


### PR DESCRIPTION
This is the same issue as [#2764](https://github.com/puphpet/puphpet/issues/2764) but on DigitalOcean instead of AWS.

With Vagrant 2.0+ you have to manually specify rsync as the method for syncing directories.